### PR TITLE
Add skeleton dataclasses, client, and backend

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - setuptools_scm
   run:
     - python >=3.9
+    - apischema
     - pcdsutils
     - pyqt
     - qtpy

--- a/docs/source/upcoming_release_notes/5-add_dataclass_skeletons.rst
+++ b/docs/source/upcoming_release_notes/5-add_dataclass_skeletons.rst
@@ -1,0 +1,22 @@
+5 add dataclass skeletons
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Add dataclasses and simple serialization tests
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- shilorigins

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # List requirements here.
+apischema
 pcdsutils
 PyQt5
 qtpy

--- a/superscore/model.py
+++ b/superscore/model.py
@@ -69,10 +69,6 @@ class Parameter(Entry):
     readback: Optional[Parameter] = None
     read_only: bool = False
 
-    def save(self) -> Value:
-        """Return a Value for this Parameter saved at the time of execution"""
-        raise NotImplementedError
-
 
 @dataclass
 class Value(Entry):
@@ -105,10 +101,6 @@ class Collection(Entry):
     title: str = ""
     children: List[Union[Parameter, Collection]] = field(default_factory=list)
     tags: Set[Tag] = field(default_factory=set)
-
-    def save(self) -> Snapshot:
-        """Return a Snapshot of this Collection saved at the time of execution"""
-        raise NotImplementedError
 
 
 @dataclass

--- a/superscore/model.py
+++ b/superscore/model.py
@@ -1,0 +1,123 @@
+"""Classes for representing data"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Flag, IntEnum, auto
+from typing import ClassVar, List, Optional, Set, Union
+from uuid import UUID, uuid4
+
+from superscore.type_hints import AnyEpicsType
+from superscore.utils import utcnow
+
+logger = logging.getLogger(__name__)
+
+
+class Severity(IntEnum):
+    NO_ALARM = auto()
+    MINOR = auto()
+    MAJOR = auto()
+    INVALID = auto()
+
+
+class Status(IntEnum):
+    NO_ALARM = auto()
+    READ = auto()
+    WRITE = auto()
+    HIHI = auto()
+    HIGH = auto()
+    LOLO = auto()
+    LOW = auto()
+    STATE = auto()
+    COS = auto()
+    COMM = auto()
+    TIMEOUT = auto()
+    HWLIMIT = auto()
+    CALC = auto()
+    SCAN = auto()
+    LINK = auto()
+    SOFT = auto()
+    BAD_SUB = auto()
+    UDF = auto()
+    DISABLE = auto()
+    SIMM = auto()
+    READ_ACCESS = auto()
+    WRITE_ACCESS = auto()
+
+
+class Tag(Flag):
+    pass
+
+
+@dataclass
+class Entry:
+    """
+    Base class for items in the data model
+    """
+    uuid: UUID = field(default_factory=uuid4)
+    description: str = ''
+    creation_time: datetime = field(default_factory=utcnow)
+
+
+@dataclass
+class Parameter(Entry):
+    """An Entry that stores a PV name"""
+    pv_name: str = ''
+    abs_tolerance: Optional[float] = 0.0
+    rel_tolerance: Optional[float] = 0.0
+    readback: Optional[Parameter] = None
+    read_only: bool = False
+
+    def save(self) -> Value:
+        """Return a Value for this Parameter saved at the time of execution"""
+        raise NotImplementedError
+
+
+@dataclass
+class Value(Entry):
+    """An Entry that stores a PV name and data pair"""
+    pv_name: str = ''
+    data: Optional[AnyEpicsType] = None
+    status: Status = Status.UDF
+    severity: Severity = Severity.INVALID
+
+
+@dataclass
+class Setpoint(Value):
+    """A Value that can be written to the EPICS environment"""
+    readback: Optional[Readback] = None
+
+
+@dataclass
+class Readback(Value):
+    """A read-only Value representing machine state that cannot be written to"""
+    abs_tolerance: Optional[float] = 0.0
+    rel_tolerance: Optional[float] = 0.0
+
+
+@dataclass
+class Collection(Entry):
+    """Nestable group of Parameters and Collections"""
+    meta_pvs: ClassVar[List[Parameter]] = []
+    all_tags: ClassVar[Set[Tag]] = set()
+
+    title: str = ""
+    children: List[Union[Parameter, Collection]] = field(default_factory=list)
+    tags: Set[Tag] = field(default_factory=set)
+
+    def save(self) -> Snapshot:
+        """Return a Snapshot of this Collection saved at the time of execution"""
+        raise NotImplementedError
+
+
+@dataclass
+class Snapshot(Entry):
+    """
+    Nestable group of Values and Snapshots.  Effectively a data-filled Collection
+    """
+    title: str = ""
+    origin_collection: Optional[UUID] = None
+    children: List[Union[Value, Snapshot]] = field(default_factory=list)
+    tags: Set[Tag] = field(default_factory=set)
+    meta_pvs: List[Value] = field(default_factory=list)

--- a/superscore/model.py
+++ b/superscore/model.py
@@ -87,10 +87,19 @@ class Setpoint(Value):
 
 @dataclass
 class Readback(Value):
-    """A read-only Value representing machine state that cannot be written to"""
+    """
+    A read-only Value representing machine state that cannot be written to. A
+    restore is considered complete when all Setpoint values are within
+    tolerance of their Readback values.
+
+    abs_tolerance - tolerance given in units matching the Setpoint
+    rel_tolerance - tolerance given as a percentage
+    timeout - time (seconds) after which a Setpoint restore is considered to
+              have failed
+    """
     abs_tolerance: Optional[float] = None
     rel_tolerance: Optional[float] = None
-    delay: Optional[float] = None
+    timeout: Optional[float] = None
 
 
 @dataclass

--- a/superscore/model.py
+++ b/superscore/model.py
@@ -64,8 +64,8 @@ class Entry:
 class Parameter(Entry):
     """An Entry that stores a PV name"""
     pv_name: str = ''
-    abs_tolerance: Optional[float] = 0.0
-    rel_tolerance: Optional[float] = 0.0
+    abs_tolerance: Optional[float] = None
+    rel_tolerance: Optional[float] = None
     readback: Optional[Parameter] = None
     read_only: bool = False
 
@@ -88,8 +88,9 @@ class Setpoint(Value):
 @dataclass
 class Readback(Value):
     """A read-only Value representing machine state that cannot be written to"""
-    abs_tolerance: Optional[float] = 0.0
-    rel_tolerance: Optional[float] = 0.0
+    abs_tolerance: Optional[float] = None
+    rel_tolerance: Optional[float] = None
+    delay: Optional[float] = None
 
 
 @dataclass

--- a/superscore/tests/test_model.py
+++ b/superscore/tests/test_model.py
@@ -19,3 +19,20 @@ def test_serialize_collection_roundtrip():
     assert deserialized.children[2] == p4
     assert deserialized.children[1].children[0] == p1
     assert deserialized.children[1].children[1] == p2
+
+
+def test_serialize_snapshot_roundtrip():
+    v1 = Value(pv_name="TEST:PV1", description="First test Value", data=4, status=Status.NO_ALARM, severity=Severity.NO_ALARM)
+    v2 = Value(pv_name="TEST:PV2", description="Second test Value", data=1.8, status=Status.UDF, severity=Severity.INVALID)
+    v3 = Value(pv_name="TEST:PV3", description="Third test Value", data="TRIM", status=Status.DISABLE, severity=Severity.NO_ALARM)
+    v4 = Value(pv_name="TEST:PV4", description="Fourth test Value", data=False, status=Status.HIGH, severity=Severity.MAJOR)
+    s1 = Snapshot(title="Snapshot 1", description="Snapshot of Inner Collection", children=[v1, v2])
+    s2 = Snapshot(title="Snapshot 2", description="Snapshot of Outer Collection", children=[v3, s1, v4])
+    serial = apischema.serialize(s2)
+    deserialized = apischema.deserialize(Snapshot, serial)
+    assert deserialized == s2
+    assert deserialized.children[0] == v3
+    assert deserialized.children[1] == s1
+    assert deserialized.children[2] == v4
+    assert deserialized.children[1].children[0] == v1
+    assert deserialized.children[1].children[1] == v2

--- a/superscore/tests/test_model.py
+++ b/superscore/tests/test_model.py
@@ -1,0 +1,21 @@
+import apischema
+
+from superscore.model import (Collection, Parameter, Severity, Snapshot,
+                              Status, Value)
+
+
+def test_serialize_collection_roundtrip():
+    p1 = Parameter(pv_name="TEST:PV1", description="First test Parameter")
+    p2 = Parameter(pv_name="TEST:PV2", description="Second test Parameter")
+    p3 = Parameter(pv_name="TEST:PV3", description="Third test Parameter")
+    p4 = Parameter(pv_name="TEST:PV4", description="Fourth test Parameter")
+    c1 = Collection(title="Collection 1", description="Inner Collection", children=[p1, p2])
+    c2 = Collection(title="Collection 2", description="Outer Collection", children=[p3, c1, p4])
+    serial = apischema.serialize(c2)
+    deserialized = apischema.deserialize(Collection, serial)
+    assert deserialized == c2
+    assert deserialized.children[0] == p3
+    assert deserialized.children[1] == c1
+    assert deserialized.children[2] == p4
+    assert deserialized.children[1].children[0] == p1
+    assert deserialized.children[1].children[1] == p2

--- a/superscore/type_hints.py
+++ b/superscore/type_hints.py
@@ -1,0 +1,3 @@
+from typing import Union
+
+AnyEpicsType = Union[int, str, float, bool]

--- a/superscore/utils.py
+++ b/superscore/utils.py
@@ -1,3 +1,8 @@
+from datetime import datetime, timezone
 from pathlib import Path
 
 SUPERSCORE_SOURCE_PATH = Path(__file__).parent
+
+
+def utcnow():
+    return datetime.now(timezone.utc)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add skeleton dataclasses (Parameter, Value, Collection, Snapshot, Setpoint, Readback), client, and backend.  Functions are defined and some default parameters given, but no implementations are supplied.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Supply interfaces so that we can begin parallel work on implementations.  Although the interfaces can change while we develop, having a rough known starting point should help if we work on separate components.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by running `pytest` from within the repo.

Further tests may be forthcoming as I review the tests from #4.
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
These interfaces are adapted from the following screenshot of our block diagrams.
<!--
## Screenshots (if appropriate):
-->
![Dataclass Diagrams](https://github.com/pcdshub/superscore/assets/29802700/96fe8eb4-8db2-4b71-a5d7-b6767a0b1601)

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
