### PR TITLE
ENH: initial skeleton for Client and Backend

### DIFF
--- a/docs/source/upcoming_release_notes/24-enh_client_backend.rst
+++ b/docs/source/upcoming_release_notes/24-enh_client_backend.rst
@@ -1,0 +1,22 @@
+24 enh_client_backend
+#####################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Add skeleton for Client and Backend base class
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/superscore/backends/core.py
+++ b/superscore/backends/core.py
@@ -1,10 +1,10 @@
 """
 Base superscore data storage backend interface
 """
-from typing import Any, Generator
+from typing import Generator
 from uuid import UUID
 
-from ..model import Entry
+from superscore.model import Entry
 
 
 class _Backend:
@@ -16,7 +16,10 @@ class _Backend:
         raise NotImplementedError
 
     def save_entry(self, entry: Entry):
-        """Save ``entry`` into the database"""
+        """
+        Save ``entry`` into the database
+        Throws BackendError if ``entry`` already exists
+        """
         raise NotImplementedError
 
     def delete_entry(self, entry: Entry) -> None:
@@ -32,6 +35,6 @@ class _Backend:
         """
         raise NotImplementedError
 
-    def search(self, **search_kwargs) -> Generator[Any, None, None]:
+    def search(self, **search_kwargs) -> Generator[Entry, None, None]:
         """Yield a Entry objects corresponding matching ``search_kwargs``"""
         raise NotImplementedError

--- a/superscore/backends/core.py
+++ b/superscore/backends/core.py
@@ -1,0 +1,37 @@
+"""
+Base superscore data storage backend interface
+"""
+from typing import Any, Generator
+from uuid import UUID
+
+from ..model import Entry
+
+
+class _Backend:
+    """
+    Base class for data storage backend.
+    """
+    def get_entry(self, meta_id: UUID) -> Entry:
+        """Get entry with ``meta_id``."""
+        raise NotImplementedError
+
+    def save_entry(self, entry: Entry):
+        """Save ``entry`` into the database"""
+        raise NotImplementedError
+
+    def delete_entry(self, entry: Entry) -> None:
+        """
+        Delete ``entry`` from the system (all instances)
+        """
+        raise NotImplementedError
+
+    def update_entry(self, entry: Entry) -> None:
+        """
+        Update ``entry`` in the backend.
+        Throws BackendError if ``entry`` does not already exist
+        """
+        raise NotImplementedError
+
+    def search(self, **search_kwargs) -> Generator[Any, None, None]:
+        """Yield a Entry objects corresponding matching ``search_kwargs``"""
+        raise NotImplementedError

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -1,0 +1,49 @@
+"""Client for superscore.  Used for programmatic interactions with superscore"""
+from typing import Any, List
+
+from superscore.backends.core import _Backend
+from superscore.model import Entry
+
+
+class Client:
+    backend: _Backend
+
+    def __init__(self, backend=None, **kwargs) -> None:
+        # if backend is None, startup default filestore backend
+        return
+
+    @classmethod
+    def from_config(cls, cfg=None):
+        raise NotImplementedError
+
+    def search(self, **post) -> List[Entry]:
+        """Search by key-value pair.  Can search by any field, including id"""
+        return self.backend.search(**post)
+
+    def save(self, entry: Entry):
+        """Save information in ``entry`` to database"""
+        # validate entry is valid
+        self.backend.save_entry(entry)
+
+    def delete(self, entry: Entry) -> None:
+        """Remove item from backend, depending on backend"""
+        # check for references to ``entry`` in other objects?
+        self.backend.delete_entry(entry)
+
+    def compare(self, entry_l: Entry, entry_r: Entry) -> Any:
+        """Compare two entries.  Should be of same type, and return a diff"""
+        raise NotImplementedError
+
+    def apply(self, entry: Entry):
+        """Apply settings found in ``entry``.  If no values found, no-op"""
+        raise NotImplementedError
+
+    def validate(self, entry: Entry):
+        """
+        Validate ``entry`` is properly formed and able to be inserted into
+        the backend.  Includes checks the following:
+        - dataclass is valid
+        - reachable from root
+        - references are not cyclical, and type-correct
+        """
+        raise NotImplementedError

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -1,5 +1,5 @@
 """Client for superscore.  Used for programmatic interactions with superscore"""
-from typing import Any, List
+from typing import Any, Generator
 
 from superscore.backends.core import _Backend
 from superscore.model import Entry
@@ -16,7 +16,7 @@ class Client:
     def from_config(cls, cfg=None):
         raise NotImplementedError
 
-    def search(self, **post) -> List[Entry]:
+    def search(self, **post) -> Generator[Entry, None, None]:
         """Search by key-value pair.  Can search by any field, including id"""
         return self.backend.search(**post)
 


### PR DESCRIPTION
## Description
Skeleton structure for Client and Backend. 
To-Do:
- figure out if we can add any reasonable tests at this point
- think about whether a "root" node is reasonable / necessary
  - My pitch for this is that we need a way to get the top-level `Entry`'s, to populate an initial preview of the database (tree view).  As it stands there's no way to distinguish a "parent" from a "child".
  - A simple way of doing this might be to just have a simple `Root` container that holds the top-level `Entry`'s.  This could have a static UUID so we can always grab it.
- add exceptions module?

## Motivation and Context
We want to broadly agree on the available methods so we can do other work.

closes #23
closes #13 

## How Has This Been Tested?
Adding some tests, we need to add more

## Where Has This Been Documented?
This PR, design doc

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
