### PR TITLE
Add initial test infrastructure: testing backend and general-use test fixture

### DIFF
--- a/docs/source/upcoming_release_notes/27-Add_testing_backend_and_linac_fixture.rst
+++ b/docs/source/upcoming_release_notes/27-Add_testing_backend_and_linac_fixture.rst
@@ -1,0 +1,25 @@
+27 Add testing backend and linac fixture
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Add custom exceptions: BackendError, FileExistsError, FileNotFoundError
+- Add TestBackend: an in-memory backend for testing purposes
+- Add LINAC Collection test fixture
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Document that _Backend.delete_entry raises error when entry is out-of-sync with backend
+- Document that _Backend.get_entry raises error when entry can't be found
+
+Contributors
+------------
+- shilorigins

--- a/superscore/backends/core.py
+++ b/superscore/backends/core.py
@@ -12,13 +12,16 @@ class _Backend:
     Base class for data storage backend.
     """
     def get_entry(self, meta_id: UUID) -> Entry:
-        """Get entry with ``meta_id``."""
+        """
+        Get entry with ``meta_id``
+        Throws EntryNotFoundError
+        """
         raise NotImplementedError
 
     def save_entry(self, entry: Entry):
         """
         Save ``entry`` into the database
-        Throws BackendError if ``entry`` already exists
+        Throws EntryExistsError
         """
         raise NotImplementedError
 
@@ -31,7 +34,7 @@ class _Backend:
     def update_entry(self, entry: Entry) -> None:
         """
         Update ``entry`` in the backend.
-        Throws BackendError if ``entry`` does not already exist
+        Throws EntryNotFoundError
         """
         raise NotImplementedError
 

--- a/superscore/backends/core.py
+++ b/superscore/backends/core.py
@@ -28,6 +28,8 @@ class _Backend:
     def delete_entry(self, entry: Entry) -> None:
         """
         Delete ``entry`` from the system (all instances)
+        Throws BackendError if backend contains an entry with the same uuid as ``entry``
+        but different data
         """
         raise NotImplementedError
 

--- a/superscore/backends/test.py
+++ b/superscore/backends/test.py
@@ -1,0 +1,48 @@
+"""
+Backend that manipulates Entries in-memory for testing purposes.
+"""
+from typing import List
+from uuid import UUID
+
+from superscore.backends.core import _Backend
+from superscore.errors import (BackendError, EntryExistsError,
+                               EntryNotFoundError)
+from superscore.model import Collection, Entry, Snapshot
+
+
+class TestBackend(_Backend):
+    """Backend that manipulates Entries in-memory, for testing purposes."""
+    def __init__(self, data: List[Entry]):
+        self.data = data
+
+    def save_entry(self, entry: Entry) -> None:
+        try:
+            self.get_entry(entry.uuid)
+            raise EntryExistsError(f"Entry {entry.uuid} already exists")
+        except EntryNotFoundError:
+            self.data.append(entry)
+
+    def get_entry(self, uuid: UUID) -> Entry:
+        stack = self.data.copy()
+        while len(stack) > 0:
+            entry = stack.pop()
+            if entry.uuid == uuid:
+                return entry
+            if isinstance(entry, Collection) or isinstance(entry, Snapshot):
+                stack.extend(entry.children)
+        raise EntryNotFoundError(f"Entry {entry.uuid} could not be found")
+
+    def update_entry(self, entry: Entry) -> None:
+        original = self.get_entry(entry.uuid)
+        original.__dict__ = entry.__dict__
+
+    def delete_entry(self, to_delete: Entry) -> None:
+        stack = [self.data.copy()]
+        while len(stack) > 0:
+            children = stack.pop()
+            for entry in children.copy():
+                if entry == to_delete:
+                    children.remove(entry)
+                elif entry.uuid == to_delete.uuid:
+                    raise BackendError(f"Can't delete: entry {to_delete.uuid} is out of sync with the version in the backend")
+            stack.extend([entry.children for entry in children if isinstance(entry, Collection) or isinstance(entry, Snapshot)])

--- a/superscore/errors.py
+++ b/superscore/errors.py
@@ -1,0 +1,16 @@
+"""Custom Exceptions"""
+
+
+class BackendError(Exception):
+    """Raised when a Backend data operation fails"""
+    pass
+
+
+class EntryExistsError(BackendError):
+    """Raised when an existing Entry is saved to the backend"""
+    pass
+
+
+class EntryNotFoundError(BackendError):
+    """Raised when an Entry is fetched from the backend but can't be found"""
+    pass

--- a/superscore/tests/conftest.py
+++ b/superscore/tests/conftest.py
@@ -1,0 +1,297 @@
+import pytest
+
+from superscore.backends.test import TestBackend
+from superscore.model import Collection, Parameter
+
+
+@pytest.fixture
+def linac_backend():
+    lasr_gunb_pv1 = Parameter(
+        uuid="5544c58f-88b6-40aa-9076-f180a44908f5",
+        pv_name="LASR:GUNB:TEST1",
+        description="First LASR pv in GUNB",
+    )
+
+    now = lasr_gunb_pv1.creation_time
+
+    lasr_gunb_pv2 = Parameter(
+        uuid="7cb3760c-793c-4974-a8ae-778e5d491e4a",
+        pv_name="LASR:GUNB:TEST2",
+        description="Second LASR pv in GUNB",
+        creation_time=now
+    )
+
+    lasr_gunb_col = Collection(
+        uuid="d5bade05-d992-4e44-87d8-0db2937209bf",
+        description="LASR devices within GUNB",
+        creation_time=now,
+        title="LASR",
+        children=[
+            lasr_gunb_pv1,
+            lasr_gunb_pv2,
+        ]
+    )
+
+    mgnt_gunb_pv = Parameter(
+        uuid="930b137f-5ae2-470e-8b82-c4b4eb7e639e",
+        pv_name="MGNT:GUNB:TEST0",
+        description="Only MGNT pv in GUNB",
+        creation_time=now
+    )
+
+    mgnt_gunb_col = Collection(
+        uuid="981d52d1-4d3c-4f85-89d7-8c04a0d588d0",
+        description="MGNT devices within GUNB",
+        creation_time=now,
+        title="MGNT",
+        children=[
+            mgnt_gunb_pv,
+        ]
+    )
+
+    vac_gunb_pv1 = Parameter(
+        uuid="8f3ac401-68f8-4def-b65a-3c8116c80ba7",
+        pv_name="VAC:GUNB:TEST1",
+        description="First VAC pv in GUNB",
+        creation_time=now
+    )
+
+    vac_gunb_pv2 = Parameter(
+        uuid="06448272-cd38-4bb4-9b8d-292673a497e9",
+        pv_name="VAC:GUNB:TEST2",
+        description="Second VAC pv in GUNB",
+        creation_time=now
+    )
+
+    vac_gunb_col = Collection(
+        uuid="e09cf046-fbf6-4d37-9ee1-c3c2dd977798",
+        description="VAC devices within GUNB",
+        creation_time=now,
+        title="VAC",
+        children=[
+            vac_gunb_pv1,
+            vac_gunb_pv2,
+        ]
+    )
+
+    gunb_col = Collection(
+        uuid="6f09255f-3424-4fc2-bbd7-ae677c8a06b9",
+        description="Injector sector for LCLS-SC",
+        creation_time=now,
+        title="GUNB",
+        children=[
+            vac_gunb_col,
+            mgnt_gunb_col,
+            lasr_gunb_col,
+        ]
+    )
+
+    vac_l0b_pv = Parameter(
+        uuid="5ec33c74-7f4c-4905-a106-44fbfe138140",
+        pv_name="VAC:L0B:TEST0",
+        description="Only VAC pv in L0B",
+        creation_time=now
+    )
+
+    vac_l0b_col = Collection(
+        uuid="aa11f29a-3e7e-4647-bfc9-133257647fb7",
+        description="First transport sector for LCLS-SC",
+        creation_time=now,
+        title="VAC",
+        children=[
+            vac_l0b_pv,
+        ]
+    )
+
+    l0b_col = Collection(
+        uuid="5e84544b-4cfa-471c-b827-80063801d27b",
+        description="First transport sector for LCLS-SC",
+        creation_time=now,
+        title="L0B",
+        children=[
+            vac_l0b_col,
+        ]
+    )
+
+    vac_bsy_pv = Parameter(
+        uuid="030786df-153b-4d29-bc1f-66deeb116724",
+        pv_name="VAC:BSY:TEST0",
+        description="Only VAC pv in BSY",
+        creation_time=now
+    )
+
+    vac_bsy_col = Collection(
+        uuid="22c2d597-2139-4c02-ac86-27f474728fad",
+        description="Vacuum devices in the BSY",
+        creation_time=now,
+        title="VAC",
+        children=[
+            vac_bsy_pv,
+        ]
+    )
+
+    bsy_col = Collection(
+        uuid="2506d87a-5980-4470-b29a-63eea183f53d",
+        description="Sector in which beam is directed towards an endpoint",
+        creation_time=now,
+        title="BSY",
+        children=[
+            vac_bsy_col,
+        ]
+    )
+
+    lcls_sc_col = Collection(
+        uuid="4732fed6-c321-4a5c-b45b-c2bf704b7fe3",
+        description="The superconducting LINAC",
+        creation_time=now,
+        title="LCLS-SC",
+        children=[
+            gunb_col,
+            l0b_col,
+            bsy_col,
+        ]
+    )
+
+    vac_li10_pv = Parameter(
+        uuid="2c83a9be-bec6-4436-8233-79df300af670",
+        pv_name="VAC:LI10:TEST0",
+        description="Only VAC pv in LI10",
+        creation_time=now
+    )
+
+    vac_li10_col = Collection(
+        uuid="214ec7c5-29d5-4827-b9dc-8da00664b462",
+        description="Vacuum devices in LI10",
+        creation_time=now,
+        title="VAC",
+        children=[
+            vac_li10_pv,
+        ]
+    )
+
+    li10_col = Collection(
+        uuid="596c4935-92eb-4bfd-a96e-b38f55f6c0a4",
+        description="First transport sector for FACET",
+        creation_time=now,
+        title="LI10",
+        children=[
+            vac_li10_col,
+        ]
+    )
+
+    lasr_in10_pv = Parameter(
+        uuid="f802dee1-569b-4c6b-a32f-c213af10ecec",
+        pv_name="LASR:IN10:TEST0",
+        description="Only laser pv in IN10",
+        creation_time=now
+    )
+
+    lasr_in10_col = Collection(
+        uuid="213b8629-8b6d-4b2a-a7a4-0201a568e8cd",
+        description="Laser devices in IN10",
+        creation_time=now,
+        title="LASR",
+        children=[
+            lasr_in10_pv,
+        ]
+    )
+
+    in10_col = Collection(
+        uuid="8395ad87-b9e9-4064-8996-316ccce9dc27",
+        description="Injector sector for FACET",
+        creation_time=now,
+        title="IN10",
+        children=[
+            lasr_in10_col,
+        ]
+    )
+
+    facet_col = Collection(
+        uuid="fe9485e0-bc36-45a4-89ec-31a4fc92ef7b",
+        description="The FACET LINAC",
+        creation_time=now,
+        title="FACET",
+        children=[
+            in10_col,
+            li10_col,
+        ]
+    )
+
+    lasr_in20_pv = Parameter(
+        uuid="a13ef8a5-b8df-4caa-80f5-395b16eaa5f1",
+        pv_name="LASR:IN20:TEST0",
+        description="Only laser pv in IN20",
+        creation_time=now
+    )
+
+    lasr_in20_col = Collection(
+        uuid="2290a098-0475-403d-a902-a26481068f25",
+        description="Laser devices in IN20",
+        creation_time=now,
+        title="LASR",
+        children=[
+            lasr_in20_pv,
+        ]
+    )
+
+    in20_col = Collection(
+        uuid="4cd08663-ee26-41ed-87d2-5ff0777e0e35",
+        description="Injector sector for LCLS-NC",
+        creation_time=now,
+        title="IN20",
+        children=[
+            lasr_in20_col,
+        ]
+    )
+
+    vac_li21_pv = Parameter(
+        uuid="8dba63d5-98e8-4647-ae44-ff0a38a4805d",
+        pv_name="VAC:LI21:TEST0",
+        description="Only VAC pv in LI21",
+        creation_time=now
+    )
+
+    vac_li21_col = Collection(
+        uuid="be3d4655-7813-4974-bb10-19e4787f8a8e",
+        description="VAC devices within LI21",
+        creation_time=now,
+        title="VAC",
+        children=[
+            vac_li21_pv,
+        ]
+    )
+
+    li21_col = Collection(
+        uuid="8b434f17-fc67-430c-aa33-d1afb64dbad2",
+        description="First transport sector for LCLS-NC",
+        creation_time=now,
+        title="LI21",
+        children=[
+            vac_li21_col,
+        ]
+    )
+
+    lcls_nc_col = Collection(
+        uuid="973ce16b-61ff-469b-a5f2-cd64783dcec5",
+        description="The normal-conducting LINAC",
+        creation_time=now,
+        title="LCLS-NC",
+        children=[
+            in20_col,
+            li21_col,
+            bsy_col,
+        ]
+    )
+
+    root_col = Collection(
+        uuid="441ff79f-4948-480e-9646-55a1462a5a70",
+        description="All three facilities in the SLAC LINAC: LCLS-NC, FACET, and LCLS-SC",
+        title="Accelerator Directorate",
+        children=[
+            lcls_nc_col,
+            facet_col,
+            lcls_sc_col,
+        ]
+    )
+
+    return TestBackend([root_col])

--- a/superscore/tests/test_backend.py
+++ b/superscore/tests/test_backend.py
@@ -1,0 +1,45 @@
+import pytest
+
+from superscore.errors import (BackendError, EntryExistsError,
+                               EntryNotFoundError)
+from superscore.model import Collection, Parameter
+
+
+class TestTestBackend:
+    def test_retrieve(self, linac_backend):
+        assert linac_backend.get_entry("441ff79f-4948-480e-9646-55a1462a5a70") is not None  # top-level Collection
+        assert linac_backend.get_entry("be3d4655-7813-4974-bb10-19e4787f8a8e") is not None  # Inner Collection
+        assert linac_backend.get_entry("2c83a9be-bec6-4436-8233-79df300af670") is not None  # Parameter
+        with pytest.raises(EntryNotFoundError):
+            linac_backend.get_entry("d3589b21-2f77-462d-9280-bb4d4e48d93b")  # Doesn't exist
+
+    def test_create(self, linac_backend):
+        collision_entry = Parameter(uuid="5ec33c74-7f4c-4905-a106-44fbfe138140")
+        with pytest.raises(EntryExistsError):
+            linac_backend.save_entry(collision_entry)
+
+        new_entry = Parameter(uuid="8913b7af-830d-4e32-bebe-b34a4616ce79")
+        linac_backend.save_entry(new_entry)
+        assert linac_backend.get_entry("8913b7af-830d-4e32-bebe-b34a4616ce79") is not None
+
+    def test_update(self, linac_backend):
+        modified_entry = Collection(uuid="d5bade05-d992-4e44-87d8-0db2937209bf", description="This is the new description")
+        linac_backend.update_entry(modified_entry)
+        assert linac_backend.get_entry(modified_entry.uuid) == modified_entry
+
+        missing_entry = Collection(uuid="d3589b21-2f77-462d-9280-bb4d4e48d93b")
+        with pytest.raises(EntryNotFoundError):
+            linac_backend.update_entry(missing_entry)
+
+    def test_delete(self, linac_backend):
+        entry = linac_backend.get_entry("2506d87a-5980-4470-b29a-63eea183f53d")
+        linac_backend.delete_entry(entry)
+        with pytest.raises(EntryNotFoundError):
+            linac_backend.get_entry("2506d87a-5980-4470-b29a-63eea183f53d")
+
+        entry = linac_backend.get_entry("aa11f29a-3e7e-4647-bfc9-133257647fb7")
+        # need new instance because editing entry would automatically sync to the backend
+        unsynced = Collection(**entry.__dict__)
+        unsynced.description = "I haven't been synced with the backend"
+        with pytest.raises(BackendError):
+            linac_backend.delete_entry(unsynced)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add `TestBackend`: stores `Entry`s in-memory for easy modification and fast access.  Direct object manipulation avoids the need to implement `update_entry` or `add_entry` at this time.

Add `linac_backend` test fixture: provides a large-ish tree of `Collection`s and `Parameter`s for tests where a larger tree is needed, such as recursive functions.  Can be modified within a test to provide different test conditions. Roughly follows the AD LINAC structure for ease of navigation.

Edit `_Backend.delete_entry` docstring to specify that the method raises an error when the `Entry` passed in as an argument is out-of-sync with the backend.  Being out-of-sync means that an `Entry` with a matching UUID exists in the backend, but its data is different. Closes #30 

Introduce custom exceptions: specifically `BackendError`, `EntryExistsError`, and `EntryNotFoundError`.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`TestBackend` provides a way for tests to fetch and modify particular `Entry`s when using fixtures.  This enables us to reuse general-use fixtures rather than creating new fixtures tailors to different tests.

Building and storing the tree in-memory decouples the fixture from (de)serialization, whose format may change over time.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I used this fixture for testing #28 , but I split it into its own PR to keep both more manageable.

I've also included tests for each of `TestBackend`'s four CRUD methods.

<details markdown="block"><summary>Test coverage</summary>

```
Name                    Stmts   Miss  Cover
-------------------------------------------
__init__.py                 2      0   100%
__main__.py                 2      2     0%
_version.py                11     11     0%
backends/__init__.py        0      0   100%
backends/core.py           14      5    64%
backends/test.py           36      0   100%
bin/__init__.py             2      2     0%
bin/help.py                11     11     0%
bin/main.py                51     51     0%
bin/ui.py                  13     13     0%
client.py                  22     22     0%
errors.py                   6      0   100%
model.py                   80      0   100%
tests/__init__.py           0      0   100%
tests/conftest.py          38      0   100%
tests/test_backend.py      34      0   100%
tests/test_model.py        32      0   100%
tests/test_window.py        5      0   100%
type_hints.py               2      0   100%
utils.py                    5      0   100%
version.py                 27     17    37%
widgets/__init__.py         0      0   100%
widgets/core.py             5      0   100%
widgets/window.py           5      0   100%
-------------------------------------------
TOTAL                     403    134    67%
```
</details>

<details><summary>Test durations</summary>

```
================================ slowest durations =================================
0.07s setup    superscore/tests/test_window.py::test_main_window
0.03s call     superscore/tests/test_window.py::test_main_window
0.01s call     superscore/tests/test_model.py::test_serialize_collection_roundtrip
0.01s call     superscore/tests/test_model.py::test_serialize_snapshot_roundtrip

(17 durations < 0.005s hidden.  Use -vv to show these durations.)
```
</details> 

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
This PR, plus some discussion in #29 
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
