### PR TITLE
Add Entry validation methods

### DIFF
--- a/docs/source/upcoming_release_notes/28-entry_validation.rst
+++ b/docs/source/upcoming_release_notes/28-entry_validation.rst
@@ -1,0 +1,23 @@
+28 entry validation
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Add validation methods to Entry and all subclasses
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Add Snapshot test fixture mirroring the LINAC Collection
+- Introduce Nestable class interface
+
+Contributors
+------------
+- shilorigins

--- a/superscore/backends/test.py
+++ b/superscore/backends/test.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from superscore.backends.core import _Backend
 from superscore.errors import (BackendError, EntryExistsError,
                                EntryNotFoundError)
-from superscore.model import Collection, Entry, Snapshot
+from superscore.model import Entry, Nestable
 
 
 class TestBackend(_Backend):
@@ -28,7 +28,7 @@ class TestBackend(_Backend):
             entry = stack.pop()
             if entry.uuid == uuid:
                 return entry
-            if isinstance(entry, Collection) or isinstance(entry, Snapshot):
+            if isinstance(entry, Nestable):
                 stack.extend(entry.children)
         raise EntryNotFoundError(f"Entry {entry.uuid} could not be found")
 
@@ -45,4 +45,4 @@ class TestBackend(_Backend):
                     children.remove(entry)
                 elif entry.uuid == to_delete.uuid:
                     raise BackendError(f"Can't delete: entry {to_delete.uuid} is out of sync with the version in the backend")
-            stack.extend([entry.children for entry in children if isinstance(entry, Collection) or isinstance(entry, Snapshot)])
+            stack.extend([entry.children for entry in children if isinstance(entry, Nestable)])

--- a/superscore/model.py
+++ b/superscore/model.py
@@ -195,16 +195,15 @@ class Nestable:
 
     def has_cycle(self, parents=None) -> bool:
         if parents is None:
-            parents = set()
+            parents = frozenset()
 
         if self.uuid in parents:
             return True
         else:
-            parents.add(self.uuid)
+            parents_including_self = parents | {self.uuid}
             for child in self.children:
-                if isinstance(child, type(self)) and child.has_cycle(parents=parents):
+                if isinstance(child, type(self)) and child.has_cycle(parents=parents_including_self):
                     return True
-            parents.remove(self.uuid)
             return False
 
 

--- a/superscore/model.py
+++ b/superscore/model.py
@@ -9,6 +9,8 @@ from enum import Flag, IntEnum, auto
 from typing import ClassVar, List, Optional, Set, Union
 from uuid import UUID, uuid4
 
+import apischema
+
 from superscore.serialization import as_tagged_union
 from superscore.type_hints import AnyEpicsType
 from superscore.utils import utcnow
@@ -73,6 +75,23 @@ class Entry:
         """
         return []
 
+    def validate(self, toplevel: bool = True) -> bool:
+        """
+        Ensures Entry is properly formed.
+
+        Raises apischema.ValidationError if type checking fails during
+        deserialization
+        """
+        if toplevel:
+            try:
+                serial = apischema.serialize(self)
+                apischema.deserialize(type(self), serial)
+                return True
+            except apischema.ValidationError:
+                return False
+        else:
+            return True
+
 
 @dataclass
 class Parameter(Entry):
@@ -82,6 +101,10 @@ class Parameter(Entry):
     rel_tolerance: Optional[float] = None
     readback: Optional[Parameter] = None
     read_only: bool = False
+
+    def validate(self, toplevel: bool = True) -> bool:
+        readback_is_valid = self.readback is None or self.readback.validate(toplevel=False)
+        return readback_is_valid and super().validate(toplevel=toplevel)
 
 
 @dataclass
@@ -109,6 +132,10 @@ class Setpoint(Entry):
             severity=severity,
             readback=origin.readback,
         )
+
+    def validate(self, toplevel: bool = True) -> bool:
+        readback_is_valid = self.readback is None or self.readback.validate(toplevel=False)
+        return readback_is_valid and super().validate(toplevel=toplevel)
 
 
 @dataclass
@@ -152,8 +179,37 @@ class Readback(Entry):
         )
 
 
+class Nestable:
+    """Mix-in class that provides methods for nested container Entries"""
+    def validate(self, toplevel: bool = True):
+        """
+        Validates self and all children. If toplevel, also validates structure
+        of the Entry tree. This avoids redundant work by only performing tree-
+        level validation once.
+
+        Overrides Entry.validate().
+        """
+        tree_is_valid = not toplevel or (not self.has_cycle() and super().validate(toplevel=True))
+        not_empty = len(self.children) > 0
+        return tree_is_valid and not_empty and all(child.validate(toplevel=False) for child in self.children)
+
+    def has_cycle(self, parents=None) -> bool:
+        if parents is None:
+            parents = set()
+
+        if self.uuid in parents:
+            return True
+        else:
+            parents.add(self.uuid)
+            for child in self.children:
+                if isinstance(child, type(self)) and child.has_cycle(parents=parents):
+                    return True
+            parents.remove(self.uuid)
+            return False
+
+
 @dataclass
-class Collection(Entry):
+class Collection(Nestable, Entry):
     """Nestable group of Parameters and Collections"""
     meta_pvs: ClassVar[List[Parameter]] = []
     all_tags: ClassVar[Set[Tag]] = set()
@@ -180,7 +236,7 @@ class Collection(Entry):
 
 
 @dataclass
-class Snapshot(Entry):
+class Snapshot(Nestable, Entry):
     """
     Nestable group of Values and Snapshots.  Effectively a data-filled Collection
     """

--- a/superscore/model.py
+++ b/superscore/model.py
@@ -190,8 +190,7 @@ class Nestable:
         Overrides Entry.validate().
         """
         tree_is_valid = not toplevel or (not self.has_cycle() and super().validate(toplevel=True))
-        not_empty = len(self.children) > 0
-        return tree_is_valid and not_empty and all(child.validate(toplevel=False) for child in self.children)
+        return tree_is_valid and all(child.validate(toplevel=False) for child in self.children)
 
     def has_cycle(self, parents=None) -> bool:
         if parents is None:

--- a/superscore/tests/conftest.py
+++ b/superscore/tests/conftest.py
@@ -7,7 +7,8 @@ import pytest
 from superscore.backends.core import _Backend
 from superscore.backends.filestore import FilestoreBackend
 from superscore.backends.test import TestBackend
-from superscore.model import Collection, Parameter, Root, Setpoint, Snapshot
+from superscore.model import (Collection, Parameter, Readback, Root, Setpoint,
+                              Snapshot)
 
 
 @pytest.fixture(scope='function')
@@ -24,7 +25,7 @@ def linac_backend():
         uuid="7cb3760c-793c-4974-a8ae-778e5d491e4a",
         pv_name="LASR:GUNB:TEST2",
         description="Second LASR pv in GUNB",
-        creation_time=now
+        creation_time=now,
     )
 
     lasr_gunb_col = Collection(
@@ -42,7 +43,7 @@ def linac_backend():
         uuid="930b137f-5ae2-470e-8b82-c4b4eb7e639e",
         pv_name="MGNT:GUNB:TEST0",
         description="Only MGNT pv in GUNB",
-        creation_time=now
+        creation_time=now,
     )
 
     mgnt_gunb_col = Collection(
@@ -59,14 +60,14 @@ def linac_backend():
         uuid="8f3ac401-68f8-4def-b65a-3c8116c80ba7",
         pv_name="VAC:GUNB:TEST1",
         description="First VAC pv in GUNB",
-        creation_time=now
+        creation_time=now,
     )
 
     vac_gunb_pv2 = Parameter(
         uuid="06448272-cd38-4bb4-9b8d-292673a497e9",
         pv_name="VAC:GUNB:TEST2",
         description="Second VAC pv in GUNB",
-        creation_time=now
+        creation_time=now,
     )
 
     vac_gunb_col = Collection(
@@ -96,7 +97,7 @@ def linac_backend():
         uuid="5ec33c74-7f4c-4905-a106-44fbfe138140",
         pv_name="VAC:L0B:TEST0",
         description="Only VAC pv in L0B",
-        creation_time=now
+        creation_time=now,
     )
 
     vac_l0b_col = Collection(
@@ -123,7 +124,7 @@ def linac_backend():
         uuid="030786df-153b-4d29-bc1f-66deeb116724",
         pv_name="VAC:BSY:TEST0",
         description="Only VAC pv in BSY",
-        creation_time=now
+        creation_time=now,
     )
 
     vac_bsy_col = Collection(
@@ -162,7 +163,7 @@ def linac_backend():
         uuid="2c83a9be-bec6-4436-8233-79df300af670",
         pv_name="VAC:LI10:TEST0",
         description="Only VAC pv in LI10",
-        creation_time=now
+        creation_time=now,
     )
 
     vac_li10_col = Collection(
@@ -189,7 +190,7 @@ def linac_backend():
         uuid="f802dee1-569b-4c6b-a32f-c213af10ecec",
         pv_name="LASR:IN10:TEST0",
         description="Only laser pv in IN10",
-        creation_time=now
+        creation_time=now,
     )
 
     lasr_in10_col = Collection(
@@ -227,7 +228,7 @@ def linac_backend():
         uuid="a13ef8a5-b8df-4caa-80f5-395b16eaa5f1",
         pv_name="LASR:IN20:TEST0",
         description="Only laser pv in IN20",
-        creation_time=now
+        creation_time=now,
     )
 
     lasr_in20_col = Collection(
@@ -254,7 +255,7 @@ def linac_backend():
         uuid="8dba63d5-98e8-4647-ae44-ff0a38a4805d",
         pv_name="VAC:LI21:TEST0",
         description="Only VAC pv in LI21",
-        creation_time=now
+        creation_time=now,
     )
 
     vac_li21_col = Collection(
@@ -289,9 +290,10 @@ def linac_backend():
         ]
     )
 
-    root_col = Collection(
+    all_col = Collection(
         uuid="441ff79f-4948-480e-9646-55a1462a5a70",
         description="All three facilities in the SLAC LINAC: LCLS-NC, FACET, and LCLS-SC",
+        creation_time=now,
         title="Accelerator Directorate",
         children=[
             lcls_nc_col,
@@ -300,7 +302,316 @@ def linac_backend():
         ]
     )
 
-    return TestBackend([root_col])
+    lasr_gunb_value1 = Setpoint(
+        uuid="927ef6cb-e45f-4175-aa5f-6c6eec1f3ae4",
+        pv_name=lasr_gunb_pv1.pv_name,
+        description=lasr_gunb_pv1.description,
+        data="Off",
+    )
+
+    now = lasr_gunb_value1.creation_time
+
+    lasr_gunb_value2 = Setpoint(
+        uuid="a221f6fa-6bc1-40ad-90fb-2041c29a5f67",
+        pv_name=lasr_gunb_pv2.pv_name,
+        description=lasr_gunb_pv2.description,
+        creation_time=now,
+        data=5,
+    )
+
+    lasr_gunb_snapshot = Snapshot(
+        uuid="2f709b4b-79da-4a8b-8693-eed2c389cb3a",
+        description=lasr_gunb_col.description,
+        creation_time=now,
+        title=lasr_gunb_col.title,
+        children=[
+            lasr_gunb_value1,
+            lasr_gunb_value2,
+        ]
+    )
+
+    mgnt_gunb_value = Setpoint(
+        uuid="502d9fc3-455a-47ea-8c48-e1a26d4d3350",
+        pv_name=mgnt_gunb_pv.pv_name,
+        description=mgnt_gunb_pv.description,
+        creation_time=now,
+        data=True,
+    )
+
+    mgnt_gunb_snapshot = Snapshot(
+        uuid="4e25ec00-3d8e-4e87-b19f-8541cb25e83b",
+        description=mgnt_gunb_col.description,
+        creation_time=now,
+        title=mgnt_gunb_col.title,
+        children=[
+            mgnt_gunb_value,
+        ]
+    )
+
+    vac_gunb_value1 = Setpoint(
+        uuid="cc187dbf-fa41-49d7-8c7b-49c8989c6a2f",
+        pv_name=vac_gunb_pv1.pv_name,
+        description=vac_gunb_pv1.description,
+        creation_time=now,
+        data="Ion Pump",
+    )
+
+    vac_gunb_value2 = Setpoint(
+        uuid="7c87960d-8b58-4b29-8d5e-e1f3223e356a",
+        pv_name=vac_gunb_pv2.pv_name,
+        description=vac_gunb_pv2.description,
+        creation_time=now,
+        data=False,
+    )
+
+    vac_gunb_snapshot = Snapshot(
+        uuid="8463a578-d327-4b92-8867-58e01c80f3c2",
+        description=vac_gunb_col.description,
+        creation_time=now,
+        title=vac_gunb_col.title,
+        children=[
+            vac_gunb_value1,
+            vac_gunb_value2,
+        ]
+    )
+
+    gunb_snapshot = Snapshot(
+        uuid="7d8655e1-c086-45a1-b89d-d5261e8375d0",
+        description=gunb_col.description,
+        creation_time=now,
+        title=gunb_col.title,
+        children=[
+            vac_gunb_snapshot,
+            mgnt_gunb_snapshot,
+            lasr_gunb_snapshot,
+        ]
+    )
+
+    vac_l0b_value = Setpoint(
+        uuid="2ef43192-40c9-4e79-96e7-2d7f6df58cd9",
+        pv_name=vac_l0b_pv.pv_name,
+        description=vac_l0b_pv.description,
+        creation_time=now,
+        data=-10,
+    )
+
+    vac_l0b_snapshot = Snapshot(
+        uuid="ed223bb4-ce6f-4b58-b53e-c2c538b1a2c7",
+        description=vac_l0b_col.description,
+        creation_time=now,
+        title=vac_l0b_col.title,
+        children=[
+            vac_l0b_value,
+        ]
+    )
+
+    l0b_snapshot = Snapshot(
+        uuid="cb2a6de0-84b4-4f9c-b7b7-ec67ccfd622f",
+        description=l0b_col.description,
+        creation_time=now,
+        title=l0b_col.title,
+        children=[
+            vac_l0b_snapshot,
+        ]
+    )
+
+    vac_bsy_value = Setpoint(
+        uuid="6bebcb59-884f-4e68-927d-f3053effd698",
+        pv_name=vac_bsy_pv.pv_name,
+        description=vac_bsy_pv.description,
+        creation_time=now,
+        data="",
+    )
+
+    vac_bsy_snapshot = Snapshot(
+        uuid="aca9400b-d37c-4b86-ada7-4801cdc6aa72",
+        description=vac_bsy_col.description,
+        creation_time=now,
+        title=vac_bsy_col.title,
+        children=[
+            vac_bsy_value,
+        ]
+    )
+
+    bsy_snapshot = Snapshot(
+        uuid="a62f1386-39de-4d19-9ea4-82f0212169a7",
+        description=bsy_col.description,
+        creation_time=now,
+        title=bsy_col.title,
+        children=[
+            vac_bsy_snapshot,
+        ]
+    )
+
+    lcls_sc_snapshot = Snapshot(
+        uuid="f01dd01b-bf48-49b2-bbb0-68dcc0b737f8",
+        description=lcls_sc_col.description,
+        creation_time=now,
+        title=lcls_sc_col.title,
+        children=[
+            gunb_snapshot,
+            l0b_snapshot,
+            bsy_snapshot,
+        ]
+    )
+
+    vac_li10_value = Setpoint(
+        uuid="ee56d60b-b8b9-447d-b857-6117e22f1462",
+        pv_name=vac_li10_pv.pv_name,
+        description=vac_li10_pv.description,
+        creation_time=now,
+        data=.25,
+    )
+
+    vac_li10_snapshot = Snapshot(
+        uuid="fb3a429c-1d2b-4505-8265-3d8988df2db1",
+        description=vac_li10_col.description,
+        creation_time=now,
+        title=vac_li10_col.title,
+        children=[
+            vac_li10_value,
+        ]
+    )
+
+    li10_snapshot = Snapshot(
+        uuid="c407e473-9287-4462-b3d3-9036008ea7f1",
+        description=li10_col.description,
+        creation_time=now,
+        title=li10_col.title,
+        children=[
+            vac_li10_snapshot,
+        ]
+    )
+
+    lasr_in10_value = Setpoint(
+        uuid="fb809d22-76fb-493e-b7f2-b522319e5e2f",
+        pv_name=lasr_in10_pv.pv_name,
+        description=lasr_in10_pv.description,
+        creation_time=now,
+        data=645.26,
+    )
+
+    lasr_in10_snapshot = Snapshot(
+        uuid="b815aed4-82b4-4dc2-9eeb-0e54bcbeb5c5",
+        description=lasr_in10_col.description,
+        creation_time=now,
+        title=lasr_in10_col.title,
+        children=[
+            lasr_in10_value,
+        ]
+    )
+
+    in10_snapshot = Snapshot(
+        uuid="5d1763cc-41a2-4c6e-bffb-4197a3994b2d",
+        description=in10_col.description,
+        creation_time=now,
+        title=in10_col.title,
+        children=[
+            lasr_in10_snapshot,
+        ]
+    )
+
+    facet_snapshot = Snapshot(
+        uuid="c48a332a-9c79-4b6f-850a-844237b83737",
+        description=facet_col.description,
+        creation_time=now,
+        title=facet_col.title,
+        children=[
+            in10_snapshot,
+            li10_snapshot,
+        ]
+    )
+
+    lasr_in20_value = Setpoint(
+        uuid="4d2f7bf2-af71-492b-8528-ba9b6e3ab964",
+        pv_name=lasr_in20_pv.pv_name,
+        description=lasr_in20_pv.description,
+        creation_time=now,
+        data=0,
+    )
+
+    lasr_in20_snapshot = Snapshot(
+        uuid="278875de-7adf-4c52-bc88-5b188eb26d4f",
+        description=lasr_in20_col.description,
+        creation_time=now,
+        title=lasr_in20_col.title,
+        children=[
+            lasr_in20_value,
+        ]
+    )
+
+    in20_snapshot = Snapshot(
+        uuid="f9965c8f-55eb-4e5c-8d52-cc939eed76db",
+        description=in20_col.description,
+        creation_time=now,
+        title=in20_col.title,
+        children=[
+            lasr_in20_snapshot,
+        ]
+    )
+
+    vac_li21_readback = Readback(
+        uuid="de66d08e-09c3-4c45-8978-900e51d00248",
+        pv_name=vac_li21_pv.pv_name,
+        description=vac_li21_pv.description,
+        creation_time=now,
+        data=0.0,
+    )
+
+    vac_li21_setpoint = Setpoint(
+        uuid="4bffe9a5-f198-41d8-90ab-870d1b5a325b",
+        pv_name=vac_li21_pv.pv_name,
+        description=vac_li21_pv.description,
+        creation_time=now,
+        data=5.0,
+        readback=vac_li21_readback,
+    )
+
+    vac_li21_snapshot = Snapshot(
+        uuid="97833e7b-e49d-4898-a602-bb39c493b0ee",
+        description=vac_li21_col.description,
+        creation_time=now,
+        title=vac_li21_col.title,
+        children=[
+            vac_li21_setpoint,
+            vac_li21_readback,
+        ]
+    )
+
+    li21_snapshot = Snapshot(
+        uuid="63a4fab8-17f9-4066-92c7-311e2eb6a44f",
+        description=li21_col.description,
+        creation_time=now,
+        title=li21_col.title,
+        children=[
+            vac_li21_snapshot,
+        ]
+    )
+
+    lcls_nc_snapshot = Snapshot(
+        uuid="7f86856a-8963-4cf2-9830-f3cce6c1b4b2",
+        description=lcls_nc_col.description,
+        creation_time=now,
+        title=lcls_nc_col.title,
+        children=[
+            in20_snapshot,
+            li21_snapshot,
+            bsy_snapshot,
+        ]
+    )
+
+    all_snapshot = Snapshot(
+        uuid="06282731-33ea-4270-ba14-098872e627dc",
+        description=all_col.description,
+        title=all_col.title,
+        children=[
+            lcls_nc_snapshot,
+            facet_snapshot,
+            lcls_sc_snapshot,
+        ]
+    )
+
+    return TestBackend([all_col, all_snapshot])
 
 
 @pytest.fixture(scope='function')

--- a/superscore/tests/test_model.py
+++ b/superscore/tests/test_model.py
@@ -88,6 +88,10 @@ class TestEntryValidation:
         vac_bsy_col.children.append(bsy_col)
         assert not linac_model.validate()
 
+        # ensure there's no hysteresis in cycle detection
+        vac_bsy_col.children.remove(bsy_col)
+        assert linac_model.validate()
+
     @staticmethod
     def test_collection_reachable_from_snapshot_validation(linac_backend):
         linac_snapshot = linac_backend.get_entry("06282731-33ea-4270-ba14-098872e627dc")

--- a/superscore/tests/test_model.py
+++ b/superscore/tests/test_model.py
@@ -89,14 +89,14 @@ class TestEntryValidation:
             description="A Collection without any children",
             children=[],
         )
-        assert not empty_col.validate()
+        assert empty_col.validate()
 
         parent_col = Collection(
             title="Non-empty Collection",
             description="A Collection whose child is empty",
             children=[empty_col],
         )
-        assert not parent_col.validate()
+        assert parent_col.validate()
 
     @staticmethod
     def test_nestable_cycle_validation():

--- a/superscore/tests/test_model.py
+++ b/superscore/tests/test_model.py
@@ -1,7 +1,7 @@
 import apischema
 
-from superscore.model import (Collection, Parameter, Root, Setpoint, Severity,
-                              Snapshot, Status)
+from superscore.model import (Collection, Parameter, Readback, Root, Setpoint,
+                              Severity, Snapshot, Status)
 
 
 def test_serialize_collection_roundtrip():
@@ -46,56 +46,110 @@ def test_sample_database_roundtrip(sample_database: Root):
 
 class TestEntryValidation:
     @staticmethod
+    def test_parameter_readback_validation():
+        readback_pv = Parameter(
+            pv_name="TEST:PV:READBACK",
+            description="Used as a readback for another PV",
+        )
+        main_pv = Parameter(
+            pv_name="TEST:PV:MAIN",
+            description="A PV with a separate readback",
+            readback=readback_pv,
+        )
+        assert readback_pv.validate()
+        assert main_pv.validate()
+
+        readback_pv.abs_tolerance = "1"
+        assert not main_pv.validate()
+
+    @staticmethod
+    def test_setpoint_validation():
+        readback = Readback(
+            pv_name="TEST:PV:READBACK",
+            description="Used as a readback for another PV",
+            data=0.0,
+        )
+        setpoint = Setpoint(
+            pv_name="TEST:PV:SETPOINT",
+            description="A PV with a separate readback",
+            data=5.0,
+            readback=readback,
+            creation_time=readback.creation_time,
+        )
+        assert readback.validate()
+        assert setpoint.validate()
+
+        readback.rel_tolerance = "10%"
+        assert not setpoint.validate()
+
+    @staticmethod
+    def test_nestable_empty_validation():
+        empty_col = Collection(
+            title="Emtpy Collection",
+            description="A Collection without any children",
+            children=[],
+        )
+        assert not empty_col.validate()
+
+        parent_col = Collection(
+            title="Non-empty Collection",
+            description="A Collection whose child is empty",
+            children=[empty_col],
+        )
+        assert not parent_col.validate()
+
+    @staticmethod
+    def test_nestable_cycle_validation():
+        pv = Parameter(
+            pv_name="TEST:PV:1",
+            description="An ordinary, valid PV",
+        )
+        col = Collection(
+            title="Collection",
+            description="A valid Collection that becomes invalid when it becomes its own parent",
+            children=[pv]
+        )
+        assert col.validate()
+
+        col.children.append(col)
+        assert not col.validate()
+
+        # ensure there's no hysteresis in cycle detection
+        col.children.remove(col)
+        assert col.validate()
+
+    @staticmethod
+    def test_collection_reachable_from_snapshot_validation():
+        pv = Parameter(
+            pv_name="TEST:PV:1",
+            description="An ordinary, valid PV",
+        )
+        col = Collection(
+            title="Collection",
+            description="An ordinary, valid Collection",
+            children=[pv]
+        )
+        assert col.validate()
+
+        setpoint = Setpoint(
+            pv_name=pv.pv_name,
+            description=pv.description,
+            data=0,
+        )
+        snapshot = Snapshot(
+            title="Snapshot",
+            description="A valid Snapshot that becomes invalid when it gains a child Collection",
+            children=[setpoint]
+        )
+        assert snapshot.validate()
+
+        snapshot.children.append(col)
+        assert not snapshot.validate()
+
+    @staticmethod
     def test_fixture_validation(linac_backend):
         linac_model = linac_backend.get_entry("441ff79f-4948-480e-9646-55a1462a5a70")
         assert linac_model.validate()
 
         linac_snapshot = linac_backend.get_entry("06282731-33ea-4270-ba14-098872e627dc")
         assert linac_snapshot.validate()
-
-    @staticmethod
-    def test_parameter_readback_validation(linac_backend):
-        vac_gunb_pv1 = linac_backend.get_entry("8f3ac401-68f8-4def-b65a-3c8116c80ba7")
-        vac_gunb_pv2 = linac_backend.get_entry("06448272-cd38-4bb4-9b8d-292673a497e9")
-        vac_gunb_pv1.readback = vac_gunb_pv2
-        assert vac_gunb_pv1.validate()
-
-        vac_gunb_pv2.abs_tolerance = "1"
-        assert not vac_gunb_pv1.validate()
-
-    @staticmethod
-    def test_setpoint_validation(linac_backend):
-        vac_li21_readback = linac_backend.get_entry("de66d08e-09c3-4c45-8978-900e51d00248")
-        vac_li21_setpoint = linac_backend.get_entry("4bffe9a5-f198-41d8-90ab-870d1b5a325b")
-        assert vac_li21_readback.validate()
-        assert vac_li21_setpoint.validate()
-
-        vac_li21_readback.rel_tolerance = "10%"
-        assert not vac_li21_setpoint.validate()
-
-    @staticmethod
-    def test_nestable_empty_validation(linac_backend):
-        linac_model = linac_backend.get_entry("441ff79f-4948-480e-9646-55a1462a5a70")
-        vac_bsy_col = linac_backend.get_entry("22c2d597-2139-4c02-ac86-27f474728fad")
-        vac_bsy_col.children = []
-        assert not linac_model.validate()
-
-    @staticmethod
-    def test_nestable_cycle_validation(linac_backend):
-        linac_model = linac_backend.get_entry("441ff79f-4948-480e-9646-55a1462a5a70")
-        bsy_col = linac_backend.get_entry("2506d87a-5980-4470-b29a-63eea183f53d")
-        vac_bsy_col = linac_backend.get_entry("22c2d597-2139-4c02-ac86-27f474728fad")
-        vac_bsy_col.children.append(bsy_col)
-        assert not linac_model.validate()
-
-        # ensure there's no hysteresis in cycle detection
-        vac_bsy_col.children.remove(bsy_col)
-        assert linac_model.validate()
-
-    @staticmethod
-    def test_collection_reachable_from_snapshot_validation(linac_backend):
-        linac_snapshot = linac_backend.get_entry("06282731-33ea-4270-ba14-098872e627dc")
-        bsy_snapshot = linac_backend.get_entry("a62f1386-39de-4d19-9ea4-82f0212169a7")
-        vac_bsy_col = linac_backend.get_entry("22c2d597-2139-4c02-ac86-27f474728fad")
-        bsy_snapshot.children.append(vac_bsy_col)
-        assert not linac_snapshot.validate()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
* Add `.validate()` method for all `Entry` subclasses
* Introduce `Nestable` interface for `Collection` and `Snapshot`
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Validation ensures that `Entry`s are well formed before certain uses, such as inserting into a backend: close #11 

Adding validation methods to each `Entry` subclass leverages polymorphism to keep validation code close to the data being validated.  This also keeps the client or backend agnostic to the type of `Entry` being validated.

`Entry.validate()` uses an `apischema` serialization roundtrip to perform type checks. This implementation captures `ValidationError`s and returns `False` if type checks fail, but I'd be open to leaving the exception if that's preferred.  If a subclass needs specific validation tests, it can override this method; the subclass is responsible for calling `Entry.validate()` or otherwise performing type checks.

`Nestable` reduces code duplication between `Collection` and `Snapshot`, and encourages more generalized code when working with these types.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran `pytest` from within the repo. Used `linac_backend` and new `linac_snapshot` fixtures to validate the original trees, a tree with an empty `Collection`, a tree with a cycle, and class instances that fail type checks.

<details>
<summary>Test coverage</summary>

```
Name                    Stmts   Miss  Cover
-------------------------------------------
__init__.py                 2      0   100%
__main__.py                 2      2     0%
_version.py                11     11     0%
backends/__init__.py        0      0   100%
backends/core.py           14      5    64%
backends/filestore.py     147     22    85%
backends/test.py           36      0   100%
bin/__init__.py             2      2     0%
bin/help.py                11     11     0%
bin/main.py                51     51     0%
bin/ui.py                  13     13     0%
client.py                  22     22     0%
errors.py                   6      0   100%
model.py                  153      6    96%
serialization.py           61     19    69%
tests/__init__.py           0      0   100%
tests/conftest.py         107      0   100%
tests/test_backend.py      71      0   100%
tests/test_model.py        79      0   100%
tests/test_window.py        5      0   100%
type_hints.py               2      0   100%
utils.py                   11      4    64%
version.py                 27     17    37%
widgets/__init__.py         0      0   100%
widgets/core.py             5      0   100%
widgets/window.py           5      0   100%
-------------------------------------------
TOTAL                     843    185    78%
```
</details>

<details>
<summary>Test durations</summary>

```
0.05s call     superscore/tests/test_window.py::test_main_window
0.04s setup    superscore/tests/test_window.py::test_main_window
0.04s call     superscore/tests/test_backend.py::test_save_entry[0]
0.02s call     superscore/tests/test_model.py::TestEntryValidation::test_fixture_validation
0.01s call     superscore/tests/test_model.py::test_serialize_snapshot_roundtrip
0.01s call     superscore/tests/test_model.py::test_serialize_collection_roundtrip
0.01s call     superscore/tests/test_backend.py::test_search_entry[0]

(47 durations < 0.005s hidden.  Use -vv to show these durations.)
```
</details>

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
This PR
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
