### PR TITLE
TST: Implement test IOC

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -33,7 +33,9 @@ test:
   imports:
     - {{ import_name }}
   requires:
+    - caproto
     - coverage
+    - numpy
     - pytest
     - pytest-asyncio
     - pytest-qt

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,8 @@
 # These are required for developing the package (running the tests) but not
 # necessarily required for _using_ it.
+caproto
 coverage
+numpy
 pytest
 pytest-asyncio
 pytest-cov

--- a/docs/source/upcoming_release_notes/34-ioc_infrastructure.rst
+++ b/docs/source/upcoming_release_notes/34-ioc_infrastructure.rst
@@ -1,0 +1,23 @@
+34 ioc infrastructure
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- implement fixture for running IOCs that can be queried for integration tests
+- implement module that can run IOCs for demos
+
+Bugfixes
+--------
+- don't change control_layer/core.py:SHIMS when creating dummy CLs
+
+Maintenance
+-----------
+- define linac testing structure outside of fixture
+
+Contributors
+------------
+- shilorigins

--- a/superscore/control_layers/core.py
+++ b/superscore/control_layers/core.py
@@ -32,7 +32,7 @@ class ControlLayer:
     def __init__(self, *args, shims: Optional[List[str]] = None, **kwargs):
         if shims is None:
             # load all available shims
-            self.shims = SHIMS
+            self.shims = SHIMS.copy()
             logger.debug('No shims specified, loading all available communication '
                          f'shims: {list(self.shims.keys())}')
         else:

--- a/superscore/tests/conftest.py
+++ b/superscore/tests/conftest.py
@@ -742,8 +742,7 @@ class DummyShim(_BaseShim):
 @pytest.fixture(scope='function')
 def dummy_cl() -> ControlLayer:
     cl = ControlLayer()
-    cl.shims['ca'] = DummyShim()
-    cl.shims['pva'] = DummyShim()
+    cl.shims = {protocol: DummyShim() for protocol in ['ca', 'pva']}
     return cl
 
 

--- a/superscore/tests/conftest.py
+++ b/superscore/tests/conftest.py
@@ -13,10 +13,10 @@ from superscore.control_layers._base_shim import _BaseShim
 from superscore.control_layers.core import ControlLayer
 from superscore.model import (Collection, Parameter, Readback, Root, Setpoint,
                               Snapshot)
+from superscore.tests.ioc import IOCFactory
 
 
-@pytest.fixture(scope='function')
-def linac_backend():
+def linac_data():
     lasr_gunb_pv1 = Parameter(
         uuid="5544c58f-88b6-40aa-9076-f180a44908f5",
         pv_name="LASR:GUNB:TEST1",
@@ -615,6 +615,12 @@ def linac_backend():
         ]
     )
 
+    return all_col, all_snapshot
+
+
+@pytest.fixture(scope='function')
+def linac_backend():
+    all_col, all_snapshot = linac_data()
     return TestBackend([all_col, all_snapshot])
 
 
@@ -772,3 +778,10 @@ def sample_client(
     client.cl = dummy_cl
 
     return client
+
+
+@pytest.fixture(scope='module')
+def linac_ioc():
+    _, snapshot = linac_data()
+    with IOCFactory.from_entries(snapshot.children)(prefix="SCORETEST:") as ioc:
+        yield ioc

--- a/superscore/tests/ioc/__init__.py
+++ b/superscore/tests/ioc/__init__.py
@@ -1,0 +1,1 @@
+from .ioc_factory import IOCFactory  # noqa: F401

--- a/superscore/tests/ioc/ioc_factory.py
+++ b/superscore/tests/ioc/ioc_factory.py
@@ -1,0 +1,71 @@
+from multiprocessing import Process
+from typing import Iterable, Mapping, Union
+
+from caproto.server import PVGroup, pvproperty
+from caproto.server import run as run_ioc
+from epicscorelibs.ca import dbr
+
+from superscore.model import Entry, Nestable, Parameter, Readback, Setpoint
+
+
+class TempIOC(PVGroup):
+    """
+    Makes PVs accessible via EPICS when running. Instances automatically start
+    and stop running when used as a context manager, and are thus suitable for
+    use in tests.
+    """
+    def __enter__(self):
+        self.running_process = Process(
+            target=run_ioc,
+            args=(self.pvdb,),
+            daemon=True,
+        )
+        self.running_process.start()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+
+class IOCFactory:
+    """
+    Generates TempIOC subclasses bound to a set of PVs.
+    """
+    @staticmethod
+    def from_entries(entries: Iterable[Entry], **ioc_options) -> PVGroup:
+        """
+        Defines and instantiates a TempIOC subclass containing all PVs reachable
+        from entries.
+        """
+        attrs = IOCFactory.prepare_attrs(entries)
+        IOC = type("IOC", (TempIOC,), attrs)
+        return IOC
+
+    @staticmethod
+    def collect_pvs(entries: Iterable[Entry]) -> Iterable[Union[Parameter, Setpoint, Readback]]:
+        """Returns a collection of all PVs reachable from entries"""
+        pvs = []
+        q = entries.copy()
+        while len(q) > 0:
+            entry = q.pop()
+            if isinstance(entry, Nestable):
+                q.extend(entry.children)
+            else:
+                pvs.append(entry)
+        return pvs
+
+    @staticmethod
+    def prepare_attrs(entries: Iterable[Entry]) -> Mapping[str, pvproperty]:
+        """
+        Turns a collecton of PVs into a Mapping from attribute names to
+        caproto.pvproperties. The mapping is suitable for passing into a type()
+        call as the dict arg.
+        """
+        pvs = IOCFactory.collect_pvs(entries)
+        attrs = {}
+        for entry in pvs:
+            value = entry.data if isinstance(entry, (Setpoint, Readback)) else None
+            pv = pvproperty(name=entry.pv_name, doc=entry.description, value=value, dtype=dbr.DBR_STRING if isinstance(entry.data, str) else None)
+            attr = "".join([c.lower() for c in entry.pv_name if c != ':'])
+            attrs[attr] = pv
+        return attrs

--- a/superscore/tests/ioc/linac.py
+++ b/superscore/tests/ioc/linac.py
@@ -1,0 +1,15 @@
+from caproto.server import ioc_arg_parser, run
+
+from superscore.tests.conftest import linac_data
+from superscore.tests.ioc import IOCFactory
+
+if __name__ == '__main__':
+    _, snapshot = linac_data()
+    LinacIOC = IOCFactory.from_entries(snapshot.children)
+
+    ioc_options, run_options = ioc_arg_parser(
+        default_prefix='SCORETEST:',
+        desc="IOC evoking the structure of a linac",
+    )
+    ioc = LinacIOC(**ioc_options)
+    run(ioc.pvdb, **run_options)

--- a/superscore/tests/test_ioc.py
+++ b/superscore/tests/test_ioc.py
@@ -1,0 +1,20 @@
+from superscore.control_layers.core import ControlLayer
+
+
+def test_ioc(linac_ioc):
+    cl = ControlLayer()
+    assert cl.get("SCORETEST:MGNT:GUNB:TEST0").data == 1
+    cl.put("SCORETEST:MGNT:GUNB:TEST0", 0)
+    assert cl.get("SCORETEST:MGNT:GUNB:TEST0").data == 0
+
+    assert cl.get("SCORETEST:VAC:GUNB:TEST1").data == "Ion Pump"
+    cl.put("SCORETEST:VAC:GUNB:TEST1", "new value")
+    assert cl.get("SCORETEST:VAC:GUNB:TEST1").data == "new value"
+
+    assert cl.get("SCORETEST:LASR:GUNB:TEST2").data == 5
+    cl.put("SCORETEST:LASR:GUNB:TEST2", 10)
+    assert cl.get("SCORETEST:LASR:GUNB:TEST2").data == 10
+
+    assert cl.get("SCORETEST:LASR:IN10:TEST0").data == 645.26
+    cl.put("SCORETEST:LASR:IN10:TEST0", 600.0)
+    assert cl.get("SCORETEST:LASR:IN10:TEST0").data == 600.0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add a fixture and module for instantiating IOCs that make PVs accessible via EPICS during tests and for live interaction (closes #31) 

Fix a bug where the `dummy_cl` fixture was altering the `SHIMS` global variable, causing the IOC test to fail only if run after `test_cl.py`.  I did this both by making a new dict in `dummy_cl`, and by copying `SHIMS` in `ControlLayer.__init__` rather than assigning it to an instance attribute.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### Motivation

This application needs to interface with EPICS via Channel Access and PV Access, so we need a way to test this interface. While mocking can be useful, using actual EPICS tools in at least some tests will make the test suite more complete. This test IOC system is intended to provide test PVs that use the same interface as and behave like production PVs, while being predicable, repeatable, and configurable.

### Design

Because `caproto` IOCs use class attributes to store their PVs, all desired PVs must be passed in before the IOC class is defined, instantiated, and run (there may be a way to reconfigure IOCs after subclassing / instantiation, but I haven't figured it out). `IOCFactory` collects any "PV"s within a group of `Entry` trees, which includes `Parameter`s, `Setpoint`s, and `Readback`s, then defines and instantiates a test IOC subclass. These instances can be used as context managers, automatically starting and stopping themselves for the test scope.

The prefix in the test example helps prevent test PVs from colliding with production PVs in the same EPICS namespace.

### Intended use

This IOC fixture is intended to be used for integration tests, where we can scope the fixture to the module and limit the number of IOC instantiations.

To run the IOC for live interaction, run `python -m superscore.tests.ioc.linac` in a terminal.  You can then query the IOC's PVs from another terminal, or background the process and query it from the same terminal.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Basic PV interaction test in `test_ioc.py`

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
This PR
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
