### PR TITLE
ENH: Control layer and shim layers

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - setuptools_scm
   run:
     - python >=3.9
+    - aioca
     - apischema
     - pcdsutils
     - pyqt

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -32,6 +32,7 @@ test:
   requires:
     - coverage
     - pytest
+    - pytest-asyncio
     - pytest-qt
     - sphinx
     - sphinx_rtd_theme

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,7 @@
 # necessarily required for _using_ it.
 coverage
 pytest
+pytest-asyncio
 pytest-cov
 pytest-qt
 

--- a/docs/source/upcoming_release_notes/35-enh_control_layer.rst
+++ b/docs/source/upcoming_release_notes/35-enh_control_layer.rst
@@ -1,0 +1,23 @@
+35 enh_control_layer
+####################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Adds shim layer for aioca (async Channel Access)
+- Adds ControlLayer class for communicating with shims
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,4 @@ file = "dev-requirements.txt"
 file = "docs-requirements.txt"
 
 [tool.pytest.ini_options]
-addopts = "--cov=."
+addopts = "--cov=. --asyncio-mode=auto"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # List requirements here.
+aioca
 apischema
 pcdsutils
 PyQt5

--- a/superscore/control_layers/__init__.py
+++ b/superscore/control_layers/__init__.py
@@ -1,0 +1,1 @@
+from .core import ControlLayer  # noqa

--- a/superscore/control_layers/_aioca.py
+++ b/superscore/control_layers/_aioca.py
@@ -5,10 +5,10 @@ from typing import Any, Callable
 
 from aioca import caget, camonitor, caput
 
-from superscore.control_layers._base_shim import _ShimBase
+from superscore.control_layers._base_shim import _BaseShim
 
 
-class AiocaShim(_ShimBase):
+class AiocaShim(_BaseShim):
     # TODO: consider handling datatype arguments in caput/get
     # TODO: wrap CANothing results into unified status object
     async def get(self, address: str):

--- a/superscore/control_layers/_aioca.py
+++ b/superscore/control_layers/_aioca.py
@@ -1,21 +1,31 @@
 """
 Control layer shim for communicating asynchronously through channel access
 """
+import logging
 from typing import Any, Callable
 
-from aioca import caget, camonitor, caput
+from aioca import CANothing, caget, camonitor, caput
 
 from superscore.control_layers._base_shim import _BaseShim
+from superscore.errors import CommunicationError
+
+logger = logging.getLogger(__name__)
 
 
 class AiocaShim(_BaseShim):
-    # TODO: consider handling datatype arguments in caput/get
-    # TODO: wrap CANothing results into unified status object
     async def get(self, address: str):
-        return await caget(address)
+        try:
+            return await caget(address)
+        except CANothing as ex:
+            logger.debug(f"CA get failed {ex.__repr__()}")
+            raise CommunicationError(f'CA get failed for {ex}')
 
     async def put(self, address: str, value: Any):
-        await caput(address, value)
+        try:
+            await caput(address, value)
+        except CANothing as ex:
+            logger.debug(f"CA put failed {ex.__repr__()}")
+            raise CommunicationError(f'CA put failed for {ex}')
 
     def monitor(self, address: str, callback: Callable):
         camonitor(address, callback)

--- a/superscore/control_layers/_aioca.py
+++ b/superscore/control_layers/_aioca.py
@@ -5,7 +5,7 @@ from typing import Any, Callable
 
 from aioca import caget, camonitor, caput
 
-from ._base_shim import _ShimBase
+from superscore.control_layers._base_shim import _ShimBase
 
 
 class AiocaShim(_ShimBase):
@@ -15,7 +15,7 @@ class AiocaShim(_ShimBase):
         return await caget(address)
 
     async def put(self, address: str, value: Any):
-        return await caput(address, value)
+        await caput(address, value)
 
     def monitor(self, address: str, callback: Callable):
         camonitor(address, callback)

--- a/superscore/control_layers/_aioca.py
+++ b/superscore/control_layers/_aioca.py
@@ -13,19 +13,63 @@ logger = logging.getLogger(__name__)
 
 
 class AiocaShim(_BaseShim):
-    async def get(self, address: str):
+    """async compatible EPICS channel access shim layer"""
+    async def get(self, address: str) -> Any:
+        """
+        Get the value at the PV: ``address``.
+
+        Parameters
+        ----------
+        address : str
+            The PV to caget.
+
+        Returns
+        -------
+        Any
+            The data at ``address``.
+
+        Raises
+        ------
+        CommunicationError
+            If the caget operation fails for any reason.
+        """
         try:
             return await caget(address)
         except CANothing as ex:
             logger.debug(f"CA get failed {ex.__repr__()}")
             raise CommunicationError(f'CA get failed for {ex}')
 
-    async def put(self, address: str, value: Any):
+    async def put(self, address: str, value: Any) -> None:
+        """
+        Put ``value`` to the PV ``address``.
+
+        Parameters
+        ----------
+        address : str
+            The PV to put ``value`` to.
+        value : Any
+            Value to put to ``address``.
+
+        Raises
+        ------
+        CommunicationError
+            If the caput operation fails for any reason.
+        """
         try:
             await caput(address, value)
         except CANothing as ex:
             logger.debug(f"CA put failed {ex.__repr__()}")
             raise CommunicationError(f'CA put failed for {ex}')
 
-    def monitor(self, address: str, callback: Callable):
+    def monitor(self, address: str, callback: Callable) -> None:
+        """
+        Subscribe ``callback`` to updates on the PV ``address``.
+
+        Parameters
+        ----------
+        address : str
+            The PV to monitor.
+        callback : Callable
+            The callback to run on updates to ``address``
+        """
         camonitor(address, callback)

--- a/superscore/control_layers/_aioca.py
+++ b/superscore/control_layers/_aioca.py
@@ -1,0 +1,21 @@
+"""
+Control layer shim for communicating asynchronously through channel access
+"""
+from typing import Any, Callable
+
+from aioca import caget, camonitor, caput
+
+from ._base_shim import _ShimBase
+
+
+class AiocaShim(_ShimBase):
+    # TODO: consider handling datatype arguments in caput/get
+    # TODO: wrap CANothing results into unified status object
+    async def get(self, address: str):
+        return await caget(address)
+
+    async def put(self, address: str, value: Any):
+        return await caput(address, value)
+
+    def monitor(self, address: str, callback: Callable):
+        camonitor(address, callback)

--- a/superscore/control_layers/_base_shim.py
+++ b/superscore/control_layers/_base_shim.py
@@ -1,3 +1,6 @@
+"""
+Base shim abstract base class
+"""
 from typing import Any, Callable
 
 

--- a/superscore/control_layers/_base_shim.py
+++ b/superscore/control_layers/_base_shim.py
@@ -1,0 +1,12 @@
+from typing import Any, Callable
+
+
+class _ShimBase:
+    async def get(self, address: str):
+        raise NotImplementedError
+
+    async def put(self, address: str, value: Any):
+        raise NotImplementedError
+
+    def monitor(self, address: str, callback: Callable):
+        raise NotImplementedError

--- a/superscore/control_layers/_base_shim.py
+++ b/superscore/control_layers/_base_shim.py
@@ -3,9 +3,11 @@ Base shim abstract base class
 """
 from typing import Any, Callable
 
+from superscore.type_hints import AnyEpicsType
+
 
 class _BaseShim:
-    async def get(self, address: str):
+    async def get(self, address: str) -> AnyEpicsType:
         raise NotImplementedError
 
     async def put(self, address: str, value: Any):

--- a/superscore/control_layers/_base_shim.py
+++ b/superscore/control_layers/_base_shim.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable
 
 
-class _ShimBase:
+class _BaseShim:
     async def get(self, address: str):
         raise NotImplementedError
 

--- a/superscore/control_layers/core.py
+++ b/superscore/control_layers/core.py
@@ -4,7 +4,7 @@ and dispatches to various shims depending on the context.
 """
 import asyncio
 from functools import singledispatchmethod
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Union
 
 from superscore.control_layers.status import TaskStatus
 
@@ -25,6 +25,26 @@ class ControlLayer:
         }
 
     def shim_from_pv(self, pv: str) -> _BaseShim:
+        """
+        Determine the correct shim to use for the provided ``pv``.
+        ``pv`` can optionally hold a protocol defining prefix such as "ca://" or
+        "pva://".  If no prefix is provided, will select the first available shim.
+
+        Parameters
+        ----------
+        pv : str
+            a PV address such as "MY:PREFIX:mtr1" or "pva://MY:PREFIX:dt"
+
+        Returns
+        -------
+        _BaseShim
+            The shim held by this ControlLayer for ``pv``'s protocol
+
+        Raises
+        ------
+        ValueError
+            If pv cannot be recognized or a matching shim cannot be found
+        """
         split = pv.split("://", 1)
         if len(split) > 1:
             # We got something like pva://mydevice, so use specified comms mode
@@ -39,34 +59,88 @@ class ControlLayer:
         return shim
 
     @singledispatchmethod
-    def get(self, pv):
+    def get(self, pv: Union[str, list[str]]) -> Any:
+        """
+        Get the value(s) in ``pv``.
+        If a single pv is provided, will return a single value.
+        If a list of pvs is provided, will get the values for each asynchronously.
+
+        Parameters
+        ----------
+        pv : Union[str, list[str]]
+            The PV(s) to get values for.
+
+        Returns
+        -------
+        Any
+            The requested data
+        """
+        # Dispatches to _get_single and _get_list depending on type
         print(f"PV is of an unsupported type: {type(pv)}. Provide either "
               "a string or list of strings")
 
     @get.register
-    def _(self, pv: str):
+    def _get_single(self, pv: str) -> Any:
+        """Synchronously get a single ``pv``"""
         return asyncio.run(self._get_one(pv))
 
     @get.register
-    def _(self, pv: list):
-        coros = []
-        for p in pv:
-            coros.append(self._get_one(p))
+    def _get_list(self, pv: list) -> Any:
+        """Synchronously get a list of ``pv``"""
+        async def gathered_coros():
+            coros = []
+            for p in pv:
+                coros.append(self._get_one(p))
+            return await asyncio.gather(*coros)
 
-        loop = asyncio.get_event_loop()
-        return loop.run_until_complete(asyncio.gather(*coros))
+        return asyncio.run(gathered_coros())
 
     async def _get_one(self, pv: str):
+        """
+        Base async get function.  Use this to construct higher-level get methods
+        """
         shim = self.shim_from_pv(pv)
         return await shim.get(pv)
 
     @singledispatchmethod
-    def put(self, pv, value: Any, cb: Optional[Callable]):
+    def put(
+        self,
+        pv: Union[str, list[str]],
+        value: Union[Any, list[Any]],
+        cb: Optional[Callable] = None
+    ) -> Union[TaskStatus, list[TaskStatus]]:
+        """
+        Put ``value`` to ``pv``
+        If ``pv`` is a list, ``value`` and ``cb`` must be lists of equal length
+
+        Parameters
+        ----------
+        pv : Union[str, list[str]]
+            The PV(s) to put ``values`` to
+        value : Union[Any, list[Any]]
+            The value(s) to put to the ``pv``
+        cb : Optional[Callable], by default None
+            Callbacks to run on completion of the put task.
+            Callbacks will be called with the associated TaskStatus as its
+            sole argument
+
+        Returns
+        -------
+        Union[TaskStatus, list[TaskStatus]]
+            The TaskStatus object(s) for the put operation
+        """
+        # Dispatches to _put_single and _put_list depending on type
         print(f"PV is of an unsupported type: {type(pv)}. Provide either "
               "a string or list of strings")
 
     @put.register
-    def _(self, pv: str, value: Any, cb: Optional[Callable] = None):
+    def _put_single(
+        self,
+        pv: str,
+        value: Any,
+        cb: Optional[Callable] = None
+    ) -> TaskStatus:
+        """Synchronously put ``value`` to ``pv``, running ``cb`` on completion"""
         async def status_coro():
             status = self._put_one(pv, value)
             if cb is not None:
@@ -77,7 +151,26 @@ class ControlLayer:
         return asyncio.run(status_coro())
 
     @put.register
-    def _(self, pv: list, value: list, cb: Optional[list[Callable]] = None):
+    def _put_list(
+        self,
+        pv: list,
+        value: list,
+        cb: Optional[list[Callable]] = None
+    ) -> list[TaskStatus]:
+        """
+        Synchronously put ``value`` to ``pv``, running ``cb`` on completion.
+        All arguments must be of equal length.
+        """
+        if cb is None:
+            cb_length = len(pv)
+        else:
+            cb_length = len(cb)
+
+        if not (len(pv) == len(value) == cb_length):
+            raise ValueError(
+                'Arguments are of different length: '
+                f'pvs({len(pv)}), values({len(value)}), cbs({len(cb)})'
+            )
 
         async def status_coros():
             statuses = []
@@ -99,10 +192,13 @@ class ControlLayer:
 
     @TaskStatus.wrap
     async def _put_one(self, pv: str, value: Any):
+        """
+        Base async get function.  Use this to construct higher-level get methods
+        """
         shim = self.shim_from_pv(pv)
         await shim.put(pv, value)
 
-    def subscribe(self, pv, cb):
-        # Subscribes a callback to the PV address
+    def subscribe(self, pv: str, cb: Callable):
+        """Subscribes a callback (``cb``) to the provide address (``pv``)"""
         shim = self.shim_from_pv(pv)
         shim.monitor(pv, cb)

--- a/superscore/control_layers/core.py
+++ b/superscore/control_layers/core.py
@@ -1,0 +1,98 @@
+"""
+Main control layer objects.  Exposes basic communication operations,
+and dispatches to various shims depending on the context.
+"""
+import asyncio
+from contextlib import suppress
+from functools import singledispatchmethod
+from typing import Any, Dict
+
+from ._aioca import AiocaShim
+from ._base_shim import _ShimBase
+
+
+class ControlLayer:
+    """
+    Control Layer used to communicate with the control system, dispatching to
+    whichever shim is relevant.
+    """
+    shims: Dict[str, _ShimBase]
+
+    def __init__(self, *args, **kwargs):
+        self.shims = {
+            'ca': AiocaShim(),
+        }
+
+    def shim_from_pv(self, pv: str) -> _ShimBase:
+        split = pv.split("://", 1)
+        if len(split) > 1:
+            # We got something like pva://mydevice, so use specified comms mode
+            shim = self.shims.get(split[0], None)
+        else:
+            # No comms mode specified, use the default
+            shim = list(self.shims.values())[0]
+
+        if shim is None:
+            raise ValueError(f"PV is of an unsupported protocol: {pv}")
+
+        return shim
+
+    @singledispatchmethod
+    def get(self, pv):
+        print(f"PV is of an unsupported type: {type(pv)}. Provide either "
+              "a string or list of strings")
+
+    @get.register
+    def _(self, pv: str):
+        return asyncio.run(self._get_one(pv))
+
+    @get.register
+    def _(self, pv: list):
+        coros = []
+        for p in pv:
+            coros.append(self._get_one(p))
+
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(asyncio.gather(*coros))
+
+    async def _get_one(self, pv: str):
+        shim = self.shim_from_pv(pv)
+        return await shim.get(pv)
+
+    @singledispatchmethod
+    def put(self, pv, value: Any):
+        print(f"PV is of an unsupported type: {type(pv)}. Provide either "
+              "a string or list of strings")
+
+    @put.register
+    def _(self, pv: str, value: Any):
+        return asyncio.run(self._put_one(pv, value))
+
+    @put.register
+    def _(self, pv: list, value: list, sequential: bool = False):
+        coros = []
+        for p, val in zip(pv, value):
+            coros.append(self._put_one(p, val))
+
+        loop = asyncio.get_event_loop()
+        return loop.run_until_complete(asyncio.gather(*coros))
+
+    async def _put_one(self, pv: str, value: Any):
+        shim = self.shim_from_pv(pv)
+        return await shim.put(pv, value)
+
+    def subscribe(self, pv, cb):
+        # Subscribes a callback to the PV address
+        shim = self.shim_from_pv(pv)
+        shim.monitor(pv, cb)
+
+    def stop(self):
+        # stop all currently running tasks.
+        # TODO: make all tasks generated in superscore actually handle
+        # CancelledError properly and clean up...
+        loop = asyncio.get_event_loop()
+        pending_tasks = asyncio.all_tasks(loop)
+        for task in pending_tasks:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                loop.run_until_complete(task)

--- a/superscore/control_layers/core.py
+++ b/superscore/control_layers/core.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, Optional
 from superscore.control_layers.status import TaskStatus
 
 from ._aioca import AiocaShim
-from ._base_shim import _ShimBase
+from ._base_shim import _BaseShim
 
 
 class ControlLayer:
@@ -17,14 +17,14 @@ class ControlLayer:
     Control Layer used to communicate with the control system, dispatching to
     whichever shim is relevant.
     """
-    shims: Dict[str, _ShimBase]
+    shims: Dict[str, _BaseShim]
 
     def __init__(self, *args, **kwargs):
         self.shims = {
             'ca': AiocaShim(),
         }
 
-    def shim_from_pv(self, pv: str) -> _ShimBase:
+    def shim_from_pv(self, pv: str) -> _BaseShim:
         split = pv.split("://", 1)
         if len(split) > 1:
             # We got something like pva://mydevice, so use specified comms mode

--- a/superscore/control_layers/core.py
+++ b/superscore/control_layers/core.py
@@ -3,7 +3,6 @@ Main control layer objects.  Exposes basic communication operations,
 and dispatches to various shims depending on the context.
 """
 import asyncio
-from contextlib import suppress
 from functools import singledispatchmethod
 from typing import Any, Dict
 
@@ -85,14 +84,3 @@ class ControlLayer:
         # Subscribes a callback to the PV address
         shim = self.shim_from_pv(pv)
         shim.monitor(pv, cb)
-
-    def stop(self):
-        # stop all currently running tasks.
-        # TODO: make all tasks generated in superscore actually handle
-        # CancelledError properly and clean up...
-        loop = asyncio.get_event_loop()
-        pending_tasks = asyncio.all_tasks(loop)
-        for task in pending_tasks:
-            task.cancel()
-            with suppress(asyncio.CancelledError):
-                loop.run_until_complete(task)

--- a/superscore/control_layers/core.pyi
+++ b/superscore/control_layers/core.pyi
@@ -1,0 +1,30 @@
+from typing import Any, Callable, Optional, overload
+
+from superscore.control_layers.status import TaskStatus
+
+class ControlLayer:
+    @overload
+    def get(self, pv: str) -> Any:
+        ...
+
+    @overload
+    def get(self, pv: list[str]) -> list[Any]:
+        ...
+
+    @overload
+    def put(
+        self,
+        pv: str,
+        value: Any,
+        cb: Optional[Callable] = None
+    ) -> TaskStatus:
+        ...
+
+    @overload
+    def put(
+        self,
+        pv: list,
+        value: list,
+        cb: Optional[list[Callable]] = None
+    ) -> list[TaskStatus]:
+        ...

--- a/superscore/control_layers/core.pyi
+++ b/superscore/control_layers/core.pyi
@@ -4,17 +4,17 @@ from superscore.control_layers.status import TaskStatus
 
 class ControlLayer:
     @overload
-    def get(self, pv: str) -> Any:
+    def get(self, address: str) -> Any:
         ...
 
     @overload
-    def get(self, pv: list[str]) -> list[Any]:
+    def get(self, address: list[str]) -> list[Any]:
         ...
 
     @overload
     def put(
         self,
-        pv: str,
+        address: str,
         value: Any,
         cb: Optional[Callable] = None
     ) -> TaskStatus:
@@ -23,7 +23,7 @@ class ControlLayer:
     @overload
     def put(
         self,
-        pv: list,
+        address: list,
         value: list,
         cb: Optional[list[Callable]] = None
     ) -> list[TaskStatus]:

--- a/superscore/control_layers/status.py
+++ b/superscore/control_layers/status.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import asyncio
+import functools
+from typing import Awaitable, Callable, Optional, Type, TypeVar, cast
+
+TS = TypeVar("TS", bound="TaskStatus")
+
+
+class TaskStatus:
+    """
+    Unified Status object for wrapping task completion information and attaching
+    callbacks This must be created inside of a coroutine, but can be returned to
+    synchronous scope for examining the task
+
+    Largely vendored from bluesky/ophyd-async
+    """
+
+    def __init__(self, awaitable: Awaitable):
+        if isinstance(awaitable, asyncio.Task):
+            self.task = awaitable
+        else:
+            self.task = asyncio.create_task(awaitable)
+        self.task.add_done_callback(self._run_callbacks)
+        self._callbacks: list[Callable] = []
+
+    def __await__(self):
+        return self.task.__await__()
+
+    def add_callback(self, callback: Callable):
+        if self.done:
+            callback(self)
+        else:
+            self._callbacks.append(callback)
+
+    def _run_callbacks(self, task: asyncio.Task):
+        for callback in self._callbacks:
+            callback(self)
+
+    def exception(self) -> Optional[BaseException]:
+        if self.task.done():
+            try:
+                return self.task.exception()
+            except asyncio.CancelledError as e:
+                return e
+        return None
+
+    @property
+    def done(self) -> bool:
+        return self.task.done()
+
+    @property
+    def success(self) -> bool:
+        return (
+            self.task.done()
+            and not self.task.cancelled()
+            and self.task.exception() is None
+        )
+
+    def __repr__(self) -> str:
+        if self.done:
+            if e := self.exception():
+                status = f"errored: {repr(e)}"
+            else:
+                status = "done"
+        else:
+            status = "pending"
+        return f"<{type(self).__name__}, task: {self.task.get_coro()}, {status}>"
+
+    __str__ = __repr__
+
+    @classmethod
+    def wrap(cls: Type[TS], f: Callable[..., Awaitable]) -> Callable[..., TS]:
+        """Wrap an async function in a TaskStatus."""
+
+        @functools.wraps(f)
+        def wrap_f(*args, **kwargs) -> TS:
+            return cls(f(*args, **kwargs))
+
+        return cast(Callable[..., TS], wrap_f)

--- a/superscore/errors.py
+++ b/superscore/errors.py
@@ -14,3 +14,8 @@ class EntryExistsError(BackendError):
 class EntryNotFoundError(BackendError):
     """Raised when an Entry is fetched from the backend but can't be found"""
     pass
+
+
+class CommunicationError(Exception):
+    """Raised when communication with the control system fails"""
+    pass

--- a/superscore/tests/conftest.py
+++ b/superscore/tests/conftest.py
@@ -7,6 +7,8 @@ import pytest
 from superscore.backends.core import _Backend
 from superscore.backends.filestore import FilestoreBackend
 from superscore.backends.test import TestBackend
+from superscore.control_layers._base_shim import _BaseShim
+from superscore.control_layers.core import ControlLayer
 from superscore.model import (Collection, Parameter, Readback, Root, Setpoint,
                               Snapshot)
 
@@ -675,3 +677,23 @@ def test_backends(filestore_backend: FilestoreBackend) -> List[_Backend]:
 def backends(request, test_backends: List[_Backend]):
     i = request.param
     return test_backends[i]
+
+
+class DummyShim(_BaseShim):
+    """Shim that does nothing"""
+    async def get(self, *args, **kwargs):
+        return
+
+    async def put(self, *args, **kwargs):
+        return
+
+    def monitor(self, *args, **kwargs):
+        return
+
+
+@pytest.fixture(scope='function')
+def dummy_cl() -> ControlLayer:
+    cl = ControlLayer()
+    cl.shims['ca'] = DummyShim()
+    cl.shims['pva'] = DummyShim()
+    return cl

--- a/superscore/tests/test_cl.py
+++ b/superscore/tests/test_cl.py
@@ -24,7 +24,7 @@ def test_put(dummy_cl):
 
     results = dummy_cl.put(["OTHER:PREFIX", "GE", "LT"], [4, 5, 6])
     assert all(isinstance(res, TaskStatus) for res in results)
-    assert result.done
+    assert all(res.done for res in results)
 
 
 def test_fail(dummy_cl):

--- a/superscore/tests/test_cl.py
+++ b/superscore/tests/test_cl.py
@@ -1,5 +1,7 @@
 from unittest.mock import AsyncMock
 
+import pytest
+
 from superscore.control_layers.status import TaskStatus
 
 
@@ -21,6 +23,22 @@ def test_put(dummy_cl):
     results = dummy_cl.put(["OTHER:PREFIX", "GE", "LT"], [4, 5, 6])
     assert all(isinstance(res, TaskStatus) for res in results)
     assert result.done
+
+
+def test_fail(dummy_cl):
+    mock_ca_get = AsyncMock(side_effect=ValueError)
+    dummy_cl.shims['ca'].get = mock_ca_get
+
+    # exceptions get passed through the control layer
+    with pytest.raises(ValueError):
+        dummy_cl.get("THIS:PV")
+
+    mock_ca_put = AsyncMock(side_effect=ValueError)
+    dummy_cl.shims['ca'].put = mock_ca_put
+
+    # exceptions get passed through the control layer
+    with pytest.raises(ValueError):
+        dummy_cl.put("THAT:PV", 4)
 
 
 def test_put_callback(dummy_cl):

--- a/superscore/tests/test_cl.py
+++ b/superscore/tests/test_cl.py
@@ -14,6 +14,8 @@ def test_get(dummy_cl):
     assert dummy_cl.get("ca://SOME_PREFIX") == "ca_value"
     assert dummy_cl.get("pva://SOME_PREFIX") == "pva_value"
 
+    assert dummy_cl.get(['a', 'b', 'c']) == ["ca_value" for i in range(3)]
+
 
 def test_put(dummy_cl):
     result = dummy_cl.put("OTHER:PREFIX", 4)

--- a/superscore/tests/test_cl.py
+++ b/superscore/tests/test_cl.py
@@ -1,0 +1,34 @@
+from unittest.mock import AsyncMock
+
+from superscore.control_layers.status import TaskStatus
+
+
+def test_get(dummy_cl):
+    mock_ca_get = AsyncMock(return_value='ca_value')
+    dummy_cl.shims['ca'].get = mock_ca_get
+    mock_pva_get = AsyncMock(return_value='pva_value')
+    dummy_cl.shims['pva'].get = mock_pva_get
+    assert dummy_cl.get("SOME_PREFIX") == "ca_value"
+    assert dummy_cl.get("ca://SOME_PREFIX") == "ca_value"
+    assert dummy_cl.get("pva://SOME_PREFIX") == "pva_value"
+
+
+def test_put(dummy_cl):
+    result = dummy_cl.put("OTHER:PREFIX", 4)
+    assert isinstance(result, TaskStatus)
+    assert result.done
+
+    results = dummy_cl.put(["OTHER:PREFIX", "GE", "LT"], [4, 5, 6])
+    assert all(isinstance(res, TaskStatus) for res in results)
+    assert result.done
+
+
+def test_put_callback(dummy_cl):
+    cbs = []
+
+    # callback gets called with the task as a single argument
+    result = dummy_cl.put("SOME:PREFIX", 2, cbs.append)
+
+    assert result.exception() is None
+    assert result.success is True
+    assert len(cbs) == 1

--- a/superscore/tests/test_status.py
+++ b/superscore/tests/test_status.py
@@ -1,0 +1,54 @@
+import asyncio
+from typing import Any, Callable
+
+import pytest
+
+from superscore.control_layers.status import TaskStatus
+
+
+@pytest.fixture
+async def normal_coroutine() -> Callable[[], Any]:
+    async def inner_coroutine():
+        await asyncio.sleep(0.01)
+
+    return inner_coroutine
+
+
+@pytest.fixture
+async def failing_coroutine() -> Callable[[], Any]:
+    async def inner_coroutine():
+        await asyncio.sleep(0.01)
+        raise ValueError()
+
+    return inner_coroutine
+
+
+async def test_status_success(normal_coroutine):
+    st = TaskStatus(normal_coroutine())
+    assert isinstance(st, TaskStatus)
+    assert not st.done
+    assert not st.success
+    await st
+    assert st.done
+    assert st.success
+
+
+async def test_status_fail(failing_coroutine):
+    status = TaskStatus(failing_coroutine())
+    assert status.exception() is None
+
+    with pytest.raises(ValueError):
+        await status
+
+    assert type(status.exception()) == ValueError
+
+
+async def test_status_wrap():
+    @TaskStatus.wrap
+    async def coro_status():
+        await asyncio.sleep(0.01)
+
+    st = coro_status()
+    assert isinstance(st, TaskStatus)
+    await st.task
+    assert st.done


### PR DESCRIPTION
## Description
- adds Shim layers, for unifying interface between different EPICS communication libraries
- adds ControlLayer, which dispatches to the appropriate shim layer.  The intent is for the client to hold onto a `ControlLayer` and send requests to the control system through it.

### Remaining to-do, misc thoughts
- [x] Sketch out unified "status" to track status / success of actions
- [x] Determine if shim layers need to be singletons  (No, this is fine)
- [x] Figure out what to do with data-types within shims (as is aioca only uses datatype to coerce CA information.  ignore for now)
- [x] clean up timeout errors and other dso debug output (These are log-level related.  Asyncio and setuptools_dso both have debug output)

## Motivation and Context (read: stream of tangkong's consciousness)
<details><summary>Async thoughts</summary>
<p>

### Async thoughts
We have the opportunity here to be more async about this from the start.  Since we're doing a lot of effectively IO-bound tasks (sending signal to EPICS and waiting for a response), async was a good fit.  However, I did not want to expose the async interface to the user.  I think it makes sense to stop the async-ing at the ControlLayer, so that the Client (and user) won't be exposed.  This is important if we want, frankly, anybody else at SLAC to use this code. 

#### Task Cancelling
`asyncio` has a concept of task cancelling, in which the Task receives a cancel signal and raises a CancelledError.  After this the task still needs to be awaited to complete.  Critically this is something that happens in an async coroutine.  In our case, we're sync-wrapping everything at the control layer level, so users won't have the opportunity to do this.  As such I've decided not to wrestle with this asyncio feature, though in the future we might. 

</p>
</details> 

<details><summary>What's this weird `TaskStatus` thing?</summary>
<p>

Each communication library (p4p, pyepics, aioca, etc) handles status / timeout / connection errors a bit differently.  We need a unified way to handle this in the `ControlLayer`, and for this reason I took inspiration from how `ophyd` and `ophyd-async` handle long processes.  This also gives us a place to run single-shot callbacks, since these communication libraries typically only expose a `camonitor` method, which runs callbacks on each update.  

</p>
</details> 


<details><summary>.pyi stub files</summary>
<p>

### .pyi what?
These are stub files used for static type checkers such such as mypy and pylance.  Normally we don't need this but I was trying to make `@singledispatchmethod` work.  Turns out python evaluates `@singledispatch` type decorators at runtime, using some magic shenanigans that static type checkers don't pick up.  To help people IDE's, stub files can be used with `@overload` to hint at these dispatched signatures.  For me this renders quite nicely, showing both signatures and the docstring of the application-code method.

![image](https://github.com/pcdshub/superscore/assets/35379409/1b39a86e-97b4-44e1-a792-3d17e2c4a21a)

Critically, overload and single-dispatch don't seem to play nicely together.  It is possible to define all these without stub files, but I thought moving that boiler plate out cleaned things up (and eliminated the need for `TYPE_CHECKING` check blocks)

</p>
</details> 

## How Has This Been Tested?
Interactively mostly, tests to come.

## Where Has This Been Documented?
This PR

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
