### PR TITLE
GUI: Basic GUI elements, DataWidget pages

### DIFF
--- a/docs/source/upcoming_release_notes/38-gui_main_window.rst
+++ b/docs/source/upcoming_release_notes/38-gui_main_window.rst
@@ -1,0 +1,22 @@
+38 gui_main_window
+##################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Adds DataWidget, RootModel, and related qt helpers
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/superscore/qt_helpers.py
+++ b/superscore/qt_helpers.py
@@ -1,0 +1,317 @@
+"""
+Helper QObject classes for managing dataclass instances.
+
+Contains utilities for synchronizing dataclass instances between
+widgets.
+"""
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from typing import (Any, ClassVar, Dict, List, Optional, Type, Union, get_args,
+                    get_origin, get_type_hints)
+
+from qtpy.QtCore import QObject
+from qtpy.QtCore import Signal as QSignal
+
+logger = logging.getLogger(__name__)
+
+
+class QDataclassBridge(QObject):
+    """
+    Convenience structure for managing a dataclass along with qt.
+
+    Once created, you can navigate this object much like it was the
+    dataclass. For example:
+
+    @dataclass
+    def my_class:
+        field: int
+        others: list[OtherClass]
+
+    Would allow you to access:
+    bridge.field.put(3)
+    bridge.field.changed_value.connect(my_slot)
+    bridge.others.append(OtherClass(4))
+
+    This does not recursively dive down the tree of subdataclasses.
+    For these, we need to make multiple bridges.
+
+    Parameters
+    ----------
+    data : any dataclass
+        The dataclass we want to bridge to
+    """
+    data: Any
+
+    def __init__(self, data: Any, parent: Optional[QObject] = None):
+        super().__init__(parent=parent)
+        self.data = data
+        fields = get_type_hints(type(data))
+        for name, type_hint in fields.items():
+            self.set_field_from_data(name, type_hint, data)
+
+    def set_field_from_data(
+        self,
+        name: str,
+        type_hint: Any,
+        data: Any,
+        optional: bool = False
+    ):
+        """
+        Set a field for this bridge based on the data and its type
+
+        Parameters
+        ----------
+        name : str
+            name of the field
+        type_hint : Any
+            The type hint annotation, returned from typing.get_type_hints
+        data : any
+            The dataclass for this bridge
+        """
+        # Need to figure out which category this is:
+        # 1. Primitive value -> make a QDataclassValue
+        # 2. Another dataclass -> make a QDataclassValue (object)
+        # 3. A list of values -> make a QDataclassList
+        # 4. A list of dataclasses -> QDataclassList (object)
+        origin = get_origin(type_hint)
+        args = get_args(type_hint)
+
+        if not origin:
+            # a raw type, no Union, Optional, etc
+            NestedClass = QDataclassValue
+            dtype = type_hint
+        elif origin is dict:
+            # Use dataclass value and override to object type
+            NestedClass = QDataclassValue
+            dtype = object
+        elif origin in (list, Sequence):
+            # Make sure we have list manipulation methods
+            # Sequence resolved as from collections.abc (even if defined from typing)
+            NestedClass = QDataclassList
+            dtype = args[0]
+        elif (origin is Union) and (type(None) in args):
+            # Optional, need to allow NoneType to be emitted by changed_value signal
+            if len(args) > 2:
+                # Optional + many other types, dispatch to complex Union case
+                self.set_field_from_data(name, args[:-1], data, optional=True)
+            else:
+                self.set_field_from_data(name, args[0], data, optional=True)
+            return
+        else:
+            # some complex Union? e.g. Union[str, int, bool, float]
+            logger.debug(f'Complex type hint found: {type_hint} - ({origin}, {args})')
+            NestedClass = QDataclassValue
+            dtype = object
+
+        # handle more complex datatype annotations
+        if dtype not in (int, float, bool, str):
+            dtype = object
+
+        setattr(
+            self,
+            name,
+            NestedClass.of_type(dtype, optional=optional)(
+                data,
+                name,
+                parent=self,
+            ),
+        )
+
+
+class QDataclassElem:
+    """
+    Base class for elements of the QDataclassBridge
+
+    Parameters
+    ----------
+    data : any dataclass
+        The data we want to access and update
+    attr : str
+        The dataclass attribute to connect to
+    """
+    data: Any
+    attr: str
+    updated: QSignal
+    _registry: ClassVar[Dict[str, type]]
+
+    def __init__(
+        self,
+        data: Any,
+        attr: str,
+        parent: Optional[QObject] = None,
+    ):
+        super().__init__(parent=parent)
+        self.data = data
+        self.attr = attr
+
+
+class QDataclassValue(QDataclassElem):
+    """
+    A single value in the QDataclassBridge.
+    """
+    changed_value: QSignal
+
+    _registry = {}
+
+    @classmethod
+    def of_type(
+        cls,
+        data_type: type,
+        optional: bool = False
+    ) -> Type[QDataclassValue]:
+        """
+        Create a QDataclass with a specific QSignal
+
+        Parameters
+        ----------
+        data_type : any primitive type
+        optional : bool
+            if the value is optional, True if ``None`` is a valid value
+        """
+        if optional:
+            data_type = object
+
+        try:
+            return cls._registry[(data_type, optional)]
+        except KeyError:
+            ...
+
+        new_class = type(
+            f'QDataclassValueFor{data_type.__name__}',
+            (cls, QObject),
+            {
+                'updated': QSignal(),
+                'changed_value': QSignal(data_type),
+            },
+        )
+        cls._registry[(data_type, optional)] = new_class
+        return new_class
+
+    def get(self) -> Any:
+        """
+        Return the current value.
+        """
+        return getattr(self.data, self.attr)
+
+    def put(self, value: Any):
+        """
+        Change a value on the dataclass and update consumers.
+
+        Parameters
+        ----------
+        value : any primitive type
+        """
+        setattr(self.data, self.attr, value)
+        self.changed_value.emit(self.get())
+        self.updated.emit()
+
+
+class QDataclassList(QDataclassElem):
+    """
+    A list of values in the QDataclassBridge.
+    """
+    added_value: QSignal
+    added_index: QSignal
+    removed_value: QSignal
+    removed_index: QSignal
+    changed_value: QSignal
+    changed_index: QSignal
+
+    _registry = {}
+
+    @classmethod
+    def of_type(
+        cls,
+        data_type: type,
+        optional: bool = False
+    ) -> Type[QDataclassList]:
+        """
+        Create a QDataclass with a specific QSignal
+
+        Parameters
+        ----------
+        data_type : any primitive type
+        optional : bool
+            if the value is optional, True if ``None`` is a valid value
+        """
+        if optional:
+            changed_value_type = object
+        else:
+            changed_value_type = data_type
+
+        try:
+            return cls._registry[(data_type, optional)]
+        except KeyError:
+            ...
+
+        new_class = type(
+            f'QDataclassListFor{data_type.__name__}',
+            (cls, QObject),
+            {
+                'updated': QSignal(),
+                'added_value': QSignal(data_type),
+                'added_index': QSignal(int),
+                'removed_value': QSignal(data_type),
+                'removed_index': QSignal(int),
+                'changed_value': QSignal(changed_value_type),
+                'changed_index': QSignal(int),
+            },
+        )
+        cls._registry[(data_type, optional)] = new_class
+        return new_class
+
+    def get(self) -> List[Any]:
+        """
+        Return the current list of values.
+        """
+        return getattr(self.data, self.attr)
+
+    def put(self, values: List[Any]) -> None:
+        """
+        Replace the current list of values.
+        """
+        setattr(self.data, self.attr, values)
+        self.updated.emit()
+
+    def append(self, new_value: Any) -> None:
+        """
+        Add a new value to the end of the list and update consumers.
+        """
+        data_list = self.get()
+        if data_list is None:
+            data_list = []
+            setattr(self.data, self.attr, data_list)
+        data_list.append(new_value)
+        self.added_value.emit(new_value)
+        self.added_index.emit(len(data_list) - 1)
+        self.updated.emit()
+
+    def remove_value(self, removal: Any) -> None:
+        """
+        Remove a value from the list by value and update consumers.
+        """
+        index = self.get().index(removal)
+        self.get().remove(removal)
+        self.removed_value.emit(removal)
+        self.removed_index.emit(index)
+        self.updated.emit()
+
+    def remove_index(self, index: int) -> None:
+        """
+        Remove a value from the list by index and update consumers.
+        """
+        value = self.get().pop(index)
+        self.removed_value.emit(value)
+        self.removed_index.emit(index)
+        self.updated.emit()
+
+    def put_to_index(self, index: int, new_value: Any) -> None:
+        """
+        Change a value in the list and update consumers.
+        """
+        self.get()[index] = new_value
+        self.changed_value.emit(new_value)
+        self.changed_index.emit(index)
+        self.updated.emit()

--- a/superscore/tests/test_page.py
+++ b/superscore/tests/test_page.py
@@ -1,0 +1,12 @@
+"""Largely smoke tests for various pages"""
+
+from pytestqt.qtbot import QtBot
+
+from superscore.model import Collection
+from superscore.widgets.page.entry import CollectionPage
+
+
+def test_collection_page(qtbot: QtBot):
+    data = Collection()
+    page = CollectionPage(data=data)
+    qtbot.addWidget(page)

--- a/superscore/tests/test_qt_helpers.py
+++ b/superscore/tests/test_qt_helpers.py
@@ -1,0 +1,84 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Union
+
+import pytest
+from pytestqt.qtbot import QtBot
+
+from superscore.qt_helpers import (QDataclassBridge, QDataclassList,
+                                   QDataclassValue)
+
+
+@pytest.fixture(scope='function')
+def bridge() -> QDataclassBridge:
+
+    @dataclass
+    class MyDataclass:
+        int_field: int = 2
+        bool_field: bool = True
+        str_field: str = 'stringy'
+
+        list_field: List[str] = field(default_factory=list)
+        dict_field: Dict[str, Any] = field(default_factory=dict)
+        optional_field: Optional[int] = None
+
+        union_field: Union[str, int] = 'two'
+
+    return QDataclassBridge(MyDataclass())
+
+
+def test_bridge_creation(bridge: QDataclassBridge):
+    # check correct bridge types were generated
+    assert isinstance(bridge.int_field, QDataclassValue)
+    assert 'int' in str(type(bridge.int_field))
+
+    assert isinstance(bridge.bool_field, QDataclassValue)
+    assert 'bool' in str(type(bridge.bool_field))
+
+    assert isinstance(bridge.str_field, QDataclassValue)
+    assert 'str' in str(type(bridge.str_field))
+
+    assert isinstance(bridge.list_field, QDataclassList)
+    assert 'str' in str(type(bridge.list_field))
+
+    assert isinstance(bridge.dict_field, QDataclassValue)
+    assert 'object' in str(type(bridge.dict_field))
+
+    assert isinstance(bridge.optional_field, QDataclassValue)
+    assert 'object' in str(type(bridge.optional_field))
+
+    assert isinstance(bridge.union_field, QDataclassValue)
+    assert 'object' in str(type(bridge.union_field))
+
+
+def test_value_signals(qtbot: QtBot, bridge: QDataclassBridge):
+    val = bridge.int_field
+
+    assert val.get() == 2
+    with qtbot.waitSignals([val.changed_value, val.updated]):
+        val.put(3)
+
+    assert val.get() == 3
+
+
+def test_list_signals(qtbot: QtBot, bridge: QDataclassBridge):
+    val = bridge.list_field
+
+    assert val.get() == []
+
+    with qtbot.waitSignals([val.added_value, val.added_index, val.updated]):
+        val.append('one')
+    assert val.get() == ['one']
+    val.append('end')
+    assert val.get() == ['one', 'end']
+
+    with qtbot.waitSignals([val.changed_value, val.changed_index, val.updated]):
+        val.put_to_index(0, 'zero')
+    assert val.get() == ['zero', 'end']
+
+    with qtbot.waitSignals([val.removed_value, val.removed_index, val.updated]):
+        val.remove_index(0)
+    assert val.get() == ['end']
+
+    with qtbot.waitSignals([val.removed_value, val.removed_index, val.updated]):
+        val.remove_value('end')
+    assert val.get() == []

--- a/superscore/tests/test_widgets.py
+++ b/superscore/tests/test_widgets.py
@@ -1,0 +1,49 @@
+from operator import attrgetter
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from pytestqt.qtbot import QtBot
+
+from superscore.model import Collection, Root
+from superscore.widgets.core import DataWidget
+from superscore.widgets.tree import RootTree
+
+
+@pytest.mark.parametrize(
+    'attr, signal, value',
+    [
+        ('title', 'changed_value', 'new_title'),
+        ('title', 'updated', 'new_title'),
+        ('children', 'updated', [Collection(), Collection()]),
+        ('uuid', 'changed_value', uuid4()),
+    ]
+)
+def test_collection_datawidget_bridge(
+    qtbot: QtBot,
+    attr: str,
+    signal: str,
+    value: Any
+):
+    data = Collection()
+    widget1 = DataWidget(data=data)
+    widget2 = DataWidget(data=data)
+
+    assert getattr(data, attr) != value
+
+    signal = attrgetter('.'.join((attr, signal)))(widget2.bridge)
+    with qtbot.waitSignal(signal):
+        getattr(widget1.bridge, attr).put(value)
+
+    assert getattr(data, attr) == value
+
+    qtbot.addWidget(widget1)
+    qtbot.addWidget(widget2)
+
+
+def test_roottree_setup(sample_database: Root):
+    tree_model = RootTree(base_entry=sample_database)
+    root_index = tree_model.index_from_item(tree_model.root_item)
+    # Check that the entire tree was created
+    assert tree_model.rowCount(root_index) == 4
+    assert tree_model.root_item.child(3).childCount() == 3

--- a/superscore/type_hints.py
+++ b/superscore/type_hints.py
@@ -1,3 +1,10 @@
-from typing import Union
+from typing import Dict, Protocol, Union
 
 AnyEpicsType = Union[int, str, float, bool]
+
+
+class AnyDataclass(Protocol):
+    """
+    Protocol stub shamelessly lifted from stackoverflow to hint at dataclass
+    """
+    __dataclass_fields__: Dict

--- a/superscore/ui/collection_page.ui
+++ b/superscore/ui/collection_page.ui
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QWidget" name="meta_placeholder" native="true"/>
+   </item>
+   <item>
+    <widget class="QTableWidget" name="pv_table">
+     <column>
+      <property name="text">
+       <string>PV name</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>title</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>description</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTreeView" name="child_table"/>
+   </item>
+   <item>
+    <widget class="QTextEdit" name="repr_text_edit"/>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/superscore/ui/collection_page.ui
+++ b/superscore/ui/collection_page.ui
@@ -37,7 +37,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QTreeView" name="child_table"/>
+    <widget class="QTreeView" name="child_tree_view"/>
    </item>
    <item>
     <widget class="QTextEdit" name="repr_text_edit"/>

--- a/superscore/ui/main_window.ui
+++ b/superscore/ui/main_window.ui
@@ -16,10 +16,29 @@
   <widget class="QWidget" name="central_widget">
    <layout class="QVBoxLayout" name="verticalLayout">
     <item>
-     <widget class="QTabWidget" name="tab_widget">
-      <property name="tabsClosable">
-       <bool>true</bool>
+     <widget class="QSplitter" name="splitter">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
       </property>
+      <widget class="QTreeView" name="tree_view">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+      <widget class="QTabWidget" name="tab_widget">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>3</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="tabsClosable">
+        <bool>true</bool>
+       </property>
+      </widget>
      </widget>
     </item>
    </layout>
@@ -30,21 +49,15 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>22</height>
+     <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
     <property name="title">
      <string>File</string>
     </property>
-    <addaction name="action_welcome_tab"/>
     <addaction name="separator"/>
-    <addaction name="action_new_file"/>
-    <addaction name="separator"/>
-    <addaction name="action_open_file"/>
-    <addaction name="separator"/>
-    <addaction name="action_save"/>
-    <addaction name="action_save_as"/>
+    <addaction name="action_open"/>
    </widget>
    <widget class="QMenu" name="menuDebug">
     <property name="title">
@@ -71,9 +84,9 @@
     <string>Open File</string>
    </property>
   </action>
-  <action name="action_save">
+  <action name="action_open">
    <property name="text">
-    <string>Save</string>
+    <string>Open</string>
    </property>
   </action>
   <action name="action_save_as">

--- a/superscore/ui/name_desc_tags_widget.ui
+++ b/superscore/ui/name_desc_tags_widget.ui
@@ -1,0 +1,203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>161</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QFrame" name="name_frame">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="name_label">
+        <property name="text">
+         <string>Name:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="name_edit">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="extra_text_label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="wordWrap">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="tags_frame">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="tags_label">
+        <property name="text">
+         <string>Tags:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="tags_content"/>
+      </item>
+      <item>
+       <widget class="QToolButton" name="add_tag_button">
+        <property name="text">
+         <string>+</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="desc_frame">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="desc_label">
+        <property name="text">
+         <string>Description:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPlainTextEdit" name="desc_edit"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/superscore/ui/tags_elem.ui
+++ b/superscore/ui/tags_elem.ui
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>387</width>
+    <height>22</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QLineEdit" name="line_edit">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QToolButton" name="del_button">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="baseSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>Delete item</string>
+     </property>
+     <property name="text">
+      <string>X</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/superscore/widgets/core.py
+++ b/superscore/widgets/core.py
@@ -1,10 +1,17 @@
 """
-Core classes for qt-based GUIs.
+Core widget classes for qt-based GUIs.
 """
+from __future__ import annotations
+
 from pathlib import Path
+from typing import ClassVar, List
+from weakref import WeakValueDictionary
 
 from pcdsutils.qt.designer_display import DesignerDisplay
+from qtpy import QtWidgets
 
+from superscore.qt_helpers import QDataclassBridge, QDataclassList
+from superscore.type_hints import AnyDataclass
 from superscore.utils import SUPERSCORE_SOURCE_PATH
 
 
@@ -12,3 +19,45 @@ class Display(DesignerDisplay):
     """Helper class for loading designer .ui files and adding logic"""
 
     ui_dir: Path = SUPERSCORE_SOURCE_PATH / 'ui'
+
+
+class DataWidget(QtWidgets.QWidget):
+    """
+    Base class for widgets that manipulate dataclasses.
+
+    Defines the init args for all data widgets and handles synchronization
+    of the ``QDataclassBridge`` instances. This is done so that only data
+    widgets need to consider how to handle bridges and the page classes
+    simply need to pass in data structures, rather than needing to keep track
+    of how two widgets editing the same data structure must share the same
+    bridge object.
+
+    Parameters
+    ----------
+    data : any dataclass
+        The dataclass that the widget needs to manipulate. Most widgets are
+        expecting either specific dataclasses or dataclasses that have
+        specific matching fields.
+    kwargs : QWidget kwargs
+        Passed directly to QWidget's __init__. Likely unused in most cases.
+        Even parent is unlikely to see use because parent is set automatically
+        when a widget is inserted into a layout.
+    """
+    # QDataclassBridge for this widget, other bridges may live in TreeItem
+    _bridge_cache: ClassVar[
+        WeakValueDictionary[int, QDataclassBridge]
+    ] = WeakValueDictionary()
+    bridge: QDataclassBridge
+    data: AnyDataclass
+
+    def __init__(self, data: AnyDataclass, **kwargs):
+        super().__init__(**kwargs)
+        self.data = data
+        try:
+            # TODO figure out better way to cache these
+            # TODO worried about strange deallocation timing race conditions
+            self.bridge = self._bridge_cache[id(data)]
+        except KeyError:
+            bridge = QDataclassBridge(data)
+            self._bridge_cache[id(data)] = bridge
+            self.bridge = bridge

--- a/superscore/widgets/core.py
+++ b/superscore/widgets/core.py
@@ -45,7 +45,7 @@ class DataWidget(QtWidgets.QWidget):
         Even parent is unlikely to see use because parent is set automatically
         when a widget is inserted into a layout.
     """
-    # QDataclassBridge for this widget, other bridges may live in TreeItem
+    # QDataclassBridge for this widget, other bridges may live in EntryItem
     _bridge_cache: ClassVar[
         WeakValueDictionary[int, QDataclassBridge]
     ] = WeakValueDictionary()

--- a/superscore/widgets/core.py
+++ b/superscore/widgets/core.py
@@ -13,6 +13,8 @@ from qtpy import QtWidgets
 from superscore.qt_helpers import QDataclassBridge, QDataclassList
 from superscore.type_hints import AnyDataclass
 from superscore.utils import SUPERSCORE_SOURCE_PATH
+from superscore.widgets.manip_helpers import (FrameOnEditFilter,
+                                              match_line_edit_text_width)
 
 
 class Display(DesignerDisplay):
@@ -61,3 +63,336 @@ class DataWidget(QtWidgets.QWidget):
             bridge = QDataclassBridge(data)
             self._bridge_cache[id(data)] = bridge
             self.bridge = bridge
+
+
+class NameMixin:
+    """
+    Mixin class for distributing init_name
+    """
+    def init_name(self) -> None:
+        """
+        Set up the name_edit widget appropriately.
+        """
+        # Load starting text
+        load_name = self.bridge.title.get() or ''
+        self.last_name = load_name
+        self.name_edit.setText(load_name)
+        self.on_text_changed(load_name)
+        # Set up the saving/loading
+        self.name_edit.textEdited.connect(self.update_saved_name)
+        self.name_edit.textChanged.connect(self.on_text_changed)
+        self.bridge.title.changed_value.connect(self.apply_new_name)
+
+    def update_saved_name(self, name: str) -> None:
+        """
+        When the user edits the name, write to the config.
+        """
+        self.last_name = self.name_edit.text()
+        self.bridge.title.put(name)
+
+    def apply_new_name(self, text: str) -> None:
+        """
+        If the text changed in the data, update the widget.
+
+        Only run if needed to avoid annoyance with cursor repositioning.
+        """
+        if text != self.last_name:
+            self.name_edit.setText(text)
+
+    def on_text_changed(self, text: str):
+        match_line_edit_text_width(self.name_edit, text=text)
+
+
+class NameDescTagsWidget(Display, NameMixin, DataWidget):
+    """
+    Widget for displaying and editing the name, description, and tags fields.
+
+    Any of these will be automatically disabled if the data source is missing
+    the corresponding field.
+
+    As a convenience, this also holds an "extra_text_label" QLabel for general use.
+    """
+    filename = 'name_desc_tags_widget.ui'
+
+    name_edit: QtWidgets.QLineEdit
+    name_frame: QtWidgets.QFrame
+    desc_edit: QtWidgets.QPlainTextEdit
+    desc_frame: QtWidgets.QFrame
+    tags_content: QtWidgets.QVBoxLayout
+    add_tag_button: QtWidgets.QToolButton
+    tags_frame: QtWidgets.QFrame
+    extra_text_label: QtWidgets.QLabel
+
+    def __init__(self, data: AnyDataclass, **kwargs):
+        super().__init__(data=data, **kwargs)
+        try:
+            self.bridge.title
+        except AttributeError:
+            self.name_frame.hide()
+        else:
+            self.init_name()
+        try:
+            self.bridge.description
+        except AttributeError:
+            self.desc_frame.hide()
+        else:
+            self.init_desc()
+        try:
+            self.bridge.tags
+        except AttributeError:
+            self.tags_frame.hide()
+        else:
+            self.init_tags()
+
+    def init_desc(self) -> None:
+        """
+        Set up the desc_edit widget appropriately.
+        """
+        # Load starting text
+        load_desc = self.bridge.description.get() or ''
+        self.last_desc = load_desc
+        self.desc_edit.setPlainText(load_desc)
+        # Setup the saving/loading
+        self.desc_edit.textChanged.connect(self.update_saved_desc)
+        self.bridge.description.changed_value.connect(self.apply_new_desc)
+        self.desc_edit.textChanged.connect(self.update_text_height)
+
+    def update_saved_desc(self) -> None:
+        """
+        When the user edits the desc, write to the config.
+        """
+        self.last_desc = self.desc_edit.toPlainText()
+        self.bridge.description.put(self.last_desc)
+
+    def apply_new_desc(self, desc: str) -> None:
+        """
+        When some other widget updates the description, update it here.
+        """
+        if desc != self.last_desc:
+            self.desc_edit.setPlainText(desc)
+
+    def showEvent(self, *args, **kwargs) -> None:
+        """
+        Override showEvent to update the desc height when we are shown.
+        """
+        try:
+            self.update_text_height()
+        except AttributeError:
+            pass
+        return super().showEvent(*args, **kwargs)
+
+    def resizeEvent(self, *args, **kwargs) -> None:
+        """
+        Override resizeEvent to update the desc height when we resize.
+        """
+        try:
+            self.update_text_height()
+        except AttributeError:
+            pass
+        return super().resizeEvent(*args, **kwargs)
+
+    def update_text_height(self) -> None:
+        """
+        When the user edits the desc, make the text box the correct height.
+        """
+        line_count = max(self.desc_edit.document().size().toSize().height(), 1)
+        self.desc_edit.setFixedHeight(line_count * 13 + 12)
+
+    def init_tags(self) -> None:
+        """
+        Set up the various tags widgets appropriately.
+        """
+        tags_list = TagsWidget(
+            data_list=self.bridge.tags,
+            layout=QtWidgets.QHBoxLayout(),
+        )
+        self.tags_content.addWidget(tags_list)
+
+        def add_tag() -> None:
+            if tags_list.widgets and not tags_list.widgets[-1].line_edit.text().strip():
+                # Don't add another tag if we haven't filled out the last one
+                return
+
+            elem = tags_list.add_item('')
+            elem.line_edit.setFocus()
+
+        self.add_tag_button.clicked.connect(add_tag)
+
+
+class TagsWidget(QtWidgets.QWidget):
+    """
+    A widget used to edit a QDataclassList tags field.
+
+    Aims to emulate the look and feel of typical tags fields
+    in online applications.
+
+    Parameters
+    ----------
+    data_list : QDataclassList
+        The dataclass list to edit using this widget.
+    layout : QLayout
+        The layout to use to arrange our labels. This should be an
+        instantiated but not placed layout. This lets us have some
+        flexibility in whether we arrange things horizontally,
+        vertically, etc.
+    """
+    widgets: List[TagsElem]
+
+    def __init__(
+        self,
+        data_list: QDataclassList,
+        layout: QtWidgets.QLayout,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self.data_list = data_list
+        self.setLayout(layout)
+        self.widgets = []
+        starting_list = data_list.get()
+        if starting_list is not None:
+            for starting_value in starting_list:
+                self.add_item(starting_value, init=True)
+
+    def add_item(
+        self,
+        starting_value: str,
+        init: bool = False,
+        **kwargs,
+    ) -> TagsElem:
+        """
+        Create and add new editable widget element to this widget's layout.
+
+        This can either be an existing string on the dataclass list to keep
+        track of, or it can be used to add a new string to the dataclass list.
+
+        This method will also set up the signals and slots for the new widget.
+
+        Parameters
+        ----------
+        starting_value : str
+            The starting text value for the new widget element.
+            This should match the text exactly for tracking existing
+            strings.
+        checked : bool, optional
+            This argument is unused, but it will be sent by various button
+            widgets via the "clicked" signal so it must be present.
+        init : bool, optional
+            Whether or not this is the initial initialization of this widget.
+            This will be set to True in __init__ so that we don't mutate
+            the underlying dataclass. False, the default, means that we're
+            adding a new string to the dataclass, which means we should
+            definitely append it.
+        **kwargs : from qt signals
+            Other kwargs sent along with qt signals will be ignored.
+
+        Returns
+        -------
+        strlistelem : StrListElem
+            The widget created by this function call.
+        """
+        new_widget = TagsElem(starting_value, self)
+        self.widgets.append(new_widget)
+        if not init:
+            self.data_list.append(starting_value)
+        self.layout().addWidget(new_widget)
+        return new_widget
+
+    def save_item_update(self, item: TagsElem, new_value: str) -> None:
+        """
+        Update the dataclass as appropriate when the user submits a new value.
+
+        Parameters
+        ----------
+        item : StrListElem
+            The widget that the user has edited.
+        new_value : str
+            The value that the user has submitted.
+        """
+        index = self.widgets.index(item)
+        self.data_list.put_to_index(index, new_value)
+
+    def remove_item(self, item: TagsElem) -> None:
+        """
+        Update the dataclass as appropriate when the user removes a value.
+
+        Parameters
+        ----------
+        item : StrListElem
+            The widget that the user has clicked the delete button for.
+        """
+        index = self.widgets.index(item)
+        self.widgets.remove(item)
+        self.data_list.remove_index(index)
+        item.deleteLater()
+
+
+class TagsElem(Display, QtWidgets.QWidget):
+    """
+    A single element for the TagsWidget.
+
+    Has a QLineEdit for changing the text and a delete button.
+    Changes its style to no frame when it has text and is out of focus.
+    Only shows the delete button when the text is empty.
+
+    Parameters
+    ----------
+    start_text : str
+        The starting text for this tag.
+    tags_widget : TagsWidget
+        A reference to the TagsWidget that contains this widget.
+    """
+    filename = 'tags_elem.ui'
+
+    line_edit: QtWidgets.QLineEdit
+    del_button: QtWidgets.QToolButton
+
+    def __init__(self, start_text: str, tags_widget: TagsWidget, **kwargs):
+        super().__init__(**kwargs)
+        self.line_edit.setText(start_text)
+        self.tags_widget = tags_widget
+        edit_filter = FrameOnEditFilter(parent=self)
+        edit_filter.set_no_edit_style(self.line_edit)
+        self.line_edit.installEventFilter(edit_filter)
+        self.on_text_changed(start_text)
+        self.line_edit.textChanged.connect(self.on_text_changed)
+        self.line_edit.textEdited.connect(self.on_text_edited)
+        self.del_button.clicked.connect(self.on_del_clicked)
+        icon = self.style().standardIcon(QtWidgets.QStyle.SP_TitleBarCloseButton)
+        self.del_button.setIcon(icon)
+
+    def on_text_changed(self, text: str) -> None:
+        """
+        Edit our various visual elements when the text changes.
+
+        This will do all of the following:
+        - make the delete button show only when the text field is empty
+        - adjust the size of the text field to be roughly the size of the
+          string we've inputted
+        """
+        # Show or hide the del button as needed
+        self.del_button.setVisible(not text)
+        # Adjust the width to match the text
+        match_line_edit_text_width(self.line_edit, text=text)
+
+    def on_data_changed(self, data: str) -> None:
+        """
+        Change the text displayed here using new data, if needed.
+        """
+        if self.line_edit.text() != data:
+            self.line_edit.setText(data)
+
+    def on_text_edited(self, text: str) -> None:
+        """
+        Update the dataclass when the user edits the text.
+        """
+        self.tags_widget.save_item_update(
+            item=self,
+            new_value=text,
+        )
+
+    def on_del_clicked(self, **kwargs) -> None:
+        """
+        Tell the QTagsWidget when our delete button is clicked.
+        """
+        self.tags_widget.remove_item(self)

--- a/superscore/widgets/manip_helpers.py
+++ b/superscore/widgets/manip_helpers.py
@@ -1,0 +1,117 @@
+"""
+Widget manipulation helper functions
+"""
+
+from typing import Optional
+
+from qtpy import QtCore, QtGui, QtWidgets
+
+
+class FrameOnEditFilter(QtCore.QObject):
+    """
+    A QLineEdit event filter for editing vs not editing style handling.
+
+    This will make the QLineEdit look like a QLabel when the user is
+    not editing it.
+    """
+    def eventFilter(self, object: QtWidgets.QLineEdit, event: QtCore.QEvent) -> bool:
+        # Even if we install only on line edits, this can be passed a generic
+        # QWidget when we remove and clean up the line edit widget.
+        if not isinstance(object, QtWidgets.QLineEdit):
+            return False
+        if event.type() == QtCore.QEvent.FocusIn:
+            self.set_edit_style(object)
+            return True
+        if event.type() == QtCore.QEvent.FocusOut:
+            self.set_no_edit_style(object)
+            return True
+        return False
+
+    @staticmethod
+    def set_edit_style(object: QtWidgets.QLineEdit):
+        """
+        Set a QLineEdit to the look and feel we want for editing.
+
+        Parameters
+        ----------
+        object : QLineEdit
+            Any line edit widget.
+        """
+        object.setFrame(True)
+        color = object.palette().color(QtGui.QPalette.ColorRole.Base)
+        object.setStyleSheet(
+            f"QLineEdit {{ background: rgba({color.red()},"
+            f"{color.green()}, {color.blue()}, {color.alpha()})}}"
+        )
+        object.setReadOnly(False)
+
+    @staticmethod
+    def set_no_edit_style(object: QtWidgets.QLineEdit):
+        """
+        Set a QLineEdit to the look and feel we want for not editing.
+
+        Parameters
+        ----------
+        object : QLineEdit
+            Any line edit widget.
+        """
+        if object.text():
+            object.setFrame(False)
+            object.setStyleSheet(
+                "QLineEdit { background: transparent }"
+            )
+        object.setReadOnly(True)
+
+
+def match_line_edit_text_width(
+    line_edit: QtWidgets.QLineEdit,
+    text: Optional[str] = None,
+    minimum: int = 40,
+    buffer: int = 10,
+) -> None:
+    """
+    Set the width of a line edit to match the text length.
+
+    You can use this in a slot and connect it to the line edit's
+    "textChanged" signal. This creates an effect where the line
+    edit will get longer when the user types text into it and
+    shorter when the user deletes text from it.
+
+    Parameters
+    ----------
+    line_edit : QLineEdit
+        The line edit whose width you'd like to adjust.
+    text : str, optional
+        The text to use as the basis for our size metrics.
+        In a slot you could pass in the text we get from the
+        signal update. If omitted, we'll use the current text
+        in the widget.
+    minimum : int, optional
+        The minimum width of the line edit, even when we have no
+        text. If omitted, we'll use a default value.
+    buffer : int, optional
+        The buffer we have on the right side of the rightmost
+        character in the line_edit before the edge of the widget.
+        If omitted, we'll use a default value.
+    """
+    font_metrics = line_edit.fontMetrics()
+    if text is None:
+        text = line_edit.text()
+    width = font_metrics.boundingRect(text).width()
+    line_edit.setFixedWidth(max(width + buffer, minimum))
+
+
+def insert_widget(widget: QtWidgets.QWidget, placeholder: QtWidgets.QWidget) -> None:
+    """
+    Helper function for slotting e.g. data widgets into placeholders.
+    """
+    if placeholder.layout() is None:
+        layout = QtWidgets.QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        placeholder.setLayout(layout)
+    else:
+        old_widget = placeholder.layout().takeAt(0).widget()
+        if old_widget is not None:
+            # old_widget.setParent(None)
+            old_widget.deleteLater()
+    placeholder.layout().addWidget(widget)

--- a/superscore/widgets/page/collection.py
+++ b/superscore/widgets/page/collection.py
@@ -1,0 +1,30 @@
+
+from qtpy import QtWidgets
+
+from superscore.model import Collection
+from superscore.widgets.core import DataWidget, Display, NameDescTagsWidget
+from superscore.widgets.manip_helpers import insert_widget
+
+
+class CollectionPage(Display, DataWidget):
+    filename = 'collection_page.ui'
+
+    meta_placeholder: QtWidgets.QWidget
+    meta_widget: NameDescTagsWidget
+    child_table: QtWidgets.QTreeView
+    pv_table: QtWidgets.QTableWidget
+    repr_text_edit: QtWidgets.QTextEdit
+
+    data: Collection
+
+    def __init__(self, *args, data: Collection, **kwargs):
+        super().__init__(*args, data=data, **kwargs)
+        self.setup_ui()
+
+    def setup_ui(self):
+        self.meta_widget = NameDescTagsWidget(data=self.data)
+        insert_widget(self.meta_widget, self.meta_placeholder)
+
+        self.repr_text_edit.setText(str(self.data))
+        # recurse through children and gather PVs
+        # show tree view

--- a/superscore/widgets/page/collection.py
+++ b/superscore/widgets/page/collection.py
@@ -4,6 +4,7 @@ from qtpy import QtWidgets
 from superscore.model import Collection
 from superscore.widgets.core import DataWidget, Display, NameDescTagsWidget
 from superscore.widgets.manip_helpers import insert_widget
+from superscore.widgets.tree import RootTree
 
 
 class CollectionPage(Display, DataWidget):
@@ -11,7 +12,7 @@ class CollectionPage(Display, DataWidget):
 
     meta_placeholder: QtWidgets.QWidget
     meta_widget: NameDescTagsWidget
-    child_table: QtWidgets.QTreeView
+    child_tree_view: QtWidgets.QTreeView
     pv_table: QtWidgets.QTableWidget
     repr_text_edit: QtWidgets.QTextEdit
 
@@ -28,3 +29,5 @@ class CollectionPage(Display, DataWidget):
         self.repr_text_edit.setText(str(self.data))
         # recurse through children and gather PVs
         # show tree view
+        self.model = RootTree(base_entry=self.data)
+        self.child_tree_view.setModel(self.model)

--- a/superscore/widgets/page/entry.py
+++ b/superscore/widgets/page/entry.py
@@ -1,3 +1,7 @@
+"""
+Widgets for visualizing and editing core model dataclasses
+"""
+
 
 from qtpy import QtWidgets
 

--- a/superscore/widgets/page/entry.py
+++ b/superscore/widgets/page/entry.py
@@ -2,7 +2,6 @@
 Widgets for visualizing and editing core model dataclasses
 """
 
-
 from qtpy import QtWidgets
 
 from superscore.model import Collection

--- a/superscore/widgets/tree.py
+++ b/superscore/widgets/tree.py
@@ -12,7 +12,7 @@ from PyQt5.QtCore import Qt
 from qtpy import QtCore
 
 from superscore.client import Client
-from superscore.model import Entry, Nestable
+from superscore.model import Entry, Nestable, Root
 from superscore.qt_helpers import QDataclassBridge
 
 logger = logging.getLogger(__name__)
@@ -201,7 +201,10 @@ def build_tree(entry: Entry, parent: Optional[EntryItem] = None) -> EntryItem:
     """
 
     item = EntryItem(entry, tree_parent=parent)
-    if isinstance(entry, Nestable):
+    if isinstance(entry, Root):
+        for child in entry.entries:
+            build_tree(child, parent=item)
+    elif isinstance(entry, Nestable):
         for child in entry.children:
             build_tree(child, parent=item)
 

--- a/superscore/widgets/tree.py
+++ b/superscore/widgets/tree.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+from typing import Any, ClassVar, Generator, List, Optional
+from weakref import WeakValueDictionary
+
+from PyQt5.QtCore import Qt
+from qtpy import QtCore
+
+from superscore.client import Client
+from superscore.model import Entry, Nestable
+from superscore.qt_helpers import QDataclassBridge
+from superscore.type_hints import AnyDataclass
+
+
+class EntryItem:
+    """Node representing one Entry"""
+    _bridge_cache: ClassVar[
+        WeakValueDictionary[int, QDataclassBridge]
+    ] = WeakValueDictionary()
+    bridge: QDataclassBridge
+    _data: AnyDataclass
+
+    def __init__(
+        self,
+        data: Entry,
+        tree_parent: Optional[EntryItem] = None,
+    ):
+        self._data = data
+        self._parent = None
+        self._columncount = 2
+        # Consider making children a property that looks at underlying data
+        self._children: List[EntryItem] = []
+        self._parent = None
+        self._row = 0  # (self._row)th child of this item's parent
+        if tree_parent:
+            tree_parent.addChild(self)
+
+        # Assign bridge, for updating the entry properties when data changes?
+        # For this to be relevant we need to subscribe to the bridge, maybe to
+        # change icons?
+        if self._data:
+            try:
+                self.bridge = self._bridge_cache[id(data)]
+            except KeyError:
+                bridge = QDataclassBridge(data)
+                self._bridge_cache[id(data)] = bridge
+                self.bridge = bridge
+
+    def data(self, column: int) -> Any:
+        """
+        Return the data for the requested column.
+        Column 0: name
+        Column 1: description
+
+        Parameters
+        ----------
+        column : int
+            data column requested
+
+        Returns
+        -------
+        Any
+        """
+        if self._data is None:
+            # This should never be seen
+            return '<root>'
+
+        if column == 0:
+            if isinstance(self._data, Nestable):
+                return getattr(self._data, 'title', 'root')
+            else:
+                return getattr(self._data, 'pv_name')
+        elif column == 1:
+            return getattr(self._data, 'description', 'fart')
+
+        # TODO: something about icons
+
+    def tooltip(self) -> str:
+        """Construct the tooltip based on the stored result"""
+        return ''
+
+    def columnCount(self) -> int:
+        """Return the item's column count"""
+        return self._columncount
+
+    def childCount(self) -> int:
+        """Return the item's child count"""
+        return len(self._children)
+
+    def child(self, row: int) -> EntryItem:
+        """Return the item's child"""
+        if row >= 0 and row < self.childCount():
+            return self._children[row]
+
+    def get_children(self) -> Generator[EntryItem, None, None]:
+        """Yield this item's children"""
+        yield from self._children
+
+    def parent(self) -> EntryItem:
+        """Return the item's parent"""
+        return self._parent
+
+    def row(self) -> int:
+        """Return the item's row under its parent"""
+        return self._row
+
+    def addChild(self, child: EntryItem) -> None:
+        """
+        Add a child to this item.
+
+        Parameters
+        ----------
+        child : TreeItem
+            Child TreeItem to add to this TreeItem
+        """
+        child._parent = self
+        child._row = len(self._children)
+        self._children.append(child)
+
+    def removeChild(self, child: EntryItem) -> None:
+        """Remove ``child`` from this TreeItem"""
+        self._children.remove(child)
+        child._parent = None
+        # re-assign rows to children
+        remaining_children = self.takeChildren()
+        for rchild in remaining_children:
+            self.addChild(rchild)
+
+    def replaceChild(self, old_child: EntryItem, new_child: EntryItem) -> None:
+        """Replace ``old_child`` with ``new_child``, maintaining order"""
+        for idx in range(self.childCount()):
+            if self.child(idx) is old_child:
+                self._children[idx] = new_child
+                new_child._parent = self
+                new_child._row = idx
+
+                # dereference old_child
+                old_child._parent = None
+                return
+
+        raise IndexError('old child not found, could not replace')
+
+    def takeChild(self, idx: int) -> EntryItem:
+        """Remove and return the ``idx``-th child of this item"""
+        child = self._children.pop(idx)
+        child._parent = None
+        # re-assign rows to children
+        remaining_children = self.takeChildren()
+        for rchild in remaining_children:
+            self.addChild(rchild)
+
+        return child
+
+    def insertChild(self, idx: int, child: EntryItem) -> None:
+        """Add ``child`` to this TreeItem at index ``idx``"""
+        self._children.insert(idx, child)
+        # re-assign rows to children
+        remaining_children = self.takeChildren()
+        for rchild in remaining_children:
+            self.addChild(rchild)
+
+    def takeChildren(self) -> list[EntryItem]:
+        """
+        Remove and return this item's children
+        """
+        children = self._children
+        self._children = []
+        for child in children:
+            child._parent = None
+
+        return children
+
+
+def build_tree(entry: Entry, parent: Optional[EntryItem] = None) -> EntryItem:
+    """
+    Walk down the ``entry`` tree and create an `EntryItem` for each, linking
+    them to their parents
+
+    Parameters
+    ----------
+    entry : Entry
+        the top-level item to start with
+
+    parent : EntryItem, optional
+        the parent `EntryItem` of ``entry``
+
+    Returns
+    -------
+    EntryItem
+        the constructed `EntryItem` with parent-child linkages
+    """
+
+    item = EntryItem(entry, tree_parent=parent)
+    if isinstance(entry, Nestable):
+        for child in entry.children:
+            build_tree(child, parent=item)
+
+    return item
+
+
+class RootTree(QtCore.QAbstractItemModel):
+    """
+    Item model for the database tree-view.
+    This model will query the client for entry information.
+    Attempts to be lazy with its representation, only querying data when necessary.
+    This model should only care about the metadata and structure of the Entry's
+    it displays, not the contents (pv-names, values, links, etc)
+
+    This model will be as lazy as the Client allows.  If the client can provide
+    uuid-ified entries, this model can be modified to be more performant / lazy
+
+    The base implementation likely does none of this
+    """
+    def __init__(
+        self,
+        *args,
+        base_entry: Entry,
+        client: Optional[Client] = None,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.base_entry = base_entry
+        self.root_item = build_tree(base_entry)
+        self.client = client
+        self.headers = ['name', 'description']
+
+    def headerData(
+        self,
+        section: int,
+        orientation: Qt.Orientation,
+        role: int
+    ) -> Any:
+        """
+        Returns the header data for the model.
+        Currently only displays horizontal header data
+
+        Parameters
+        ----------
+        section : int
+            section to provide header information for
+        orientation : Qt.Orientation
+            header orientation, Qt.Horizontal or Qt.Vertical
+        role : int
+            Qt role to provide header information for
+
+        Returns
+        -------
+        Any
+            requested header data
+        """
+        if role != Qt.DisplayRole:
+            return
+
+        if orientation == Qt.Horizontal:
+            return self.headers[section]
+
+    def index(
+        self,
+        row: int,
+        column: int,
+        parent: QtCore.QModelIndex = None
+    ) -> QtCore.QModelIndex:
+        """
+        Returns the index of the item in the model.
+
+        In a tree view the rows are defined relative to parent item.  If an
+        item is the first child under its parent, it will have row=0,
+        regardless of the number of items in the tree.
+
+        Parameters
+        ----------
+        row : int
+            The row of the requested index.
+        column : int
+            The column of the requested index
+        parent : QtCore.QModelIndex, optional
+            The parent of the requested index, by default None
+
+        Returns
+        -------
+        QtCore.QModelIndex
+        """
+        if not self.hasIndex(row, column, parent):
+            return QtCore.QModelIndex()
+
+        parent_item = None
+        if not parent or not parent.isValid():
+            parent_item = self.root_item
+        else:
+            parent_item = parent.internalPointer()
+
+        child_item = parent_item.child(row)
+        if child_item:
+            return self.createIndex(row, column, child_item)
+
+        # all else
+        return QtCore.QModelIndex()
+
+    def index_from_item(self, item: EntryItem) -> QtCore.QModelIndex:
+        return self.createIndex(item.row(), 0, item)
+
+    def parent(self, index: QtCore.QModelIndex) -> QtCore.QModelIndex:
+        """
+        Returns the parent of the given model item.
+
+        Parameters
+        ----------
+        index : QtCore.QModelIndex
+            item to retrieve parent of
+
+        Returns
+        -------
+        QtCore.QModelIndex
+            index of the parent item
+        """
+        if not index.isValid():
+            return QtCore.QModelIndex()
+        child = index.internalPointer()
+        if child is self.root_item:
+            return QtCore.QModelIndex()
+        parent = child.parent()
+        if parent in (self.root_item, None):
+            return QtCore.QModelIndex()
+
+        return self.createIndex(parent.row(), 0, parent)
+
+    def rowCount(self, parent: QtCore.QModelIndex) -> int:
+        """
+        Called by tree view to determine number of children an item has.
+
+        Parameters
+        ----------
+        parent : QtCore.QModelIndex
+            index of the parent item being queried
+
+        Returns
+        -------
+        int
+            number of children ``parent`` has
+        """
+        if not parent.isValid():
+            parent_item = self.root_item
+        else:
+            parent_item = parent.internalPointer()
+        return parent_item.childCount()
+
+    def columnCount(self, parent: QtCore.QModelIndex) -> int:
+        """
+        Called by tree view to determine number of columns of data ``parent`` has
+
+        Parameters
+        ----------
+        parent : QtCore.QModelIndex
+
+        Returns
+        -------
+        int
+            number of columns ``parent`` has
+        """
+        if not parent.isValid():
+            parent_item = self.root_item
+        else:
+            parent_item = parent.internalPointer()
+        return parent_item.columnCount()
+
+    def data(self, index: QtCore.QModelIndex, role: int) -> Any:
+        """
+        Returns the data stored under the given ``role`` for the item
+        referred to by the ``index``.  Uses and assumes ``TreeItem`` methods.
+
+        Parameters
+        ----------
+        index : QtCore.QModelIndex
+            index that identifies the portion of the model in question
+        role : int
+            the data role
+
+        Returns
+        -------
+        Any
+            The data to be displayed by the model
+        """
+        if not index.isValid():
+            return None
+
+        item = index.internalPointer()  # Gives original TreeItem
+        # special handling for status info
+        if index.column() == 1:
+            # if role == Qt.ForegroundRole:
+            #     brush = QBrush()
+            #     brush.setColor(item.data(index.column())[1])
+            #     return brush
+            if role == Qt.DisplayRole:
+                return item.data(1)
+            if role == Qt.TextAlignmentRole:
+                return Qt.AlignCenter
+
+        if role == Qt.ToolTipRole:
+            return item.tooltip()
+        if role == Qt.DisplayRole:
+            return item.data(index.column())
+
+        if role == Qt.UserRole:
+            return item
+
+        return None

--- a/superscore/widgets/tree.py
+++ b/superscore/widgets/tree.py
@@ -75,9 +75,9 @@ class EntryItem:
             if isinstance(self._data, Nestable):
                 return getattr(self._data, 'title', 'root')
             else:
-                return getattr(self._data, 'pv_name')
+                return getattr(self._data, 'pv_name', '<no pv>')
         elif column == 1:
-            return getattr(self._data, 'description', 'fart')
+            return getattr(self._data, 'description', '<no desc>')
 
         # TODO: something about icons
 

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -3,12 +3,18 @@ Top-level window widget that contains other widgets
 """
 from __future__ import annotations
 
-from qtpy.QtWidgets import QMainWindow
+from qtpy import QtWidgets
 
 from superscore.widgets.core import Display
 
 
-class Window(Display, QMainWindow):
+class Window(Display, QtWidgets.QMainWindow):
     """Main superscore window"""
 
     filename = 'main_window.ui'
+
+    tree_view: QtWidgets.QTreeView
+    tab_widget: QtWidgets.QTabWidget
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)


### PR DESCRIPTION
## Description
- Adds `DataWidget` and `NameDescTagsWidget`, components for making widgets that communicate with dataclasses
- Adds `EntryItem` and `RootTree` for representing Entry dataclasses in a tree view
- Adds one sample Collection widget to demonstrate how to use these widget mixins

To-Do, possibly in followup issues:
- Make a QDataclassBridge type for a set specifically, to support tag addition
- Rework Tags entry when we figure out where we're storing tags

## Motivation and Context
We need a framework to make a GUI.

I lifted most of this from ATEF, and as such we should be free to challenge any of the things we've built here.  We've found it quite useful, and I think it can be similarly useful here.  There should definitely be a keen eye taken to these.  While we've proven they work, they shouldn't be taken as gospel.  I say this partially for the review of this PR, but maybe mostly for future efforts that use these components.

The `RootModel` is very incomplete, and client interactions still need to be fleshed out.  I can see a world where we create the client on GUI startup and have some helper for fetching it, rather than passing it to every widget instance.   There was also an intent to make the data model loading lazy, and the `RootModel` is where this would manifest. But this PR is already long enough. 

If I ever have to vendor the DataWidget / QDataclassBridge stuff again I'm going to upstream it into pcdsutils.

## How Has This Been Tested?
Added some tests.

## Where Has This Been Documented?
This PR

![image](https://github.com/pcdshub/superscore/assets/35379409/935575ca-d27d-4a7d-ac58-812c23f461cf)

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
