### PR TITLE
ENH: add Client.apply method, adjust TaskStatus to properly capture exceptions

### DIFF
--- a/docs/source/upcoming_release_notes/53-enh_client_apply.rst
+++ b/docs/source/upcoming_release_notes/53-enh_client_apply.rst
@@ -1,0 +1,22 @@
+53 enh_client_apply
+###################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Implements `Client.apply` method for writing values from `Entry` data to the control system.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Adjusts `TaskStatus` use to properly capture exceptions.
+
+Contributors
+------------
+- tangkong

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -1,16 +1,23 @@
 """Client for superscore.  Used for programmatic interactions with superscore"""
-from typing import Any, Generator
+import logging
+from typing import Any, Generator, List, Optional, Union
+from uuid import UUID
 
 from superscore.backends.core import _Backend
-from superscore.model import Entry
+from superscore.control_layers import ControlLayer
+from superscore.control_layers.status import TaskStatus
+from superscore.model import Entry, Setpoint, Snapshot
+
+logger = logging.getLogger(__name__)
 
 
 class Client:
     backend: _Backend
+    cl: ControlLayer
 
-    def __init__(self, backend=None, **kwargs) -> None:
-        # if backend is None, startup default filestore backend
-        return
+    def __init__(self, backend: _Backend, **kwargs) -> None:
+        self.backend = backend
+        self.cl = ControlLayer()
 
     @classmethod
     def from_config(cls, cfg=None):
@@ -34,9 +41,106 @@ class Client:
         """Compare two entries.  Should be of same type, and return a diff"""
         raise NotImplementedError
 
-    def apply(self, entry: Entry):
-        """Apply settings found in ``entry``.  If no values found, no-op"""
-        raise NotImplementedError
+    def apply(
+        self,
+        entry: Union[Setpoint, Snapshot],
+        sequential: bool = False
+    ) -> Optional[List[TaskStatus]]:
+        """
+        Apply settings found in ``entry``.  If no writable values found, return.
+        If ``sequential`` is True, apply values in ``entry`` in sequence, blocking
+        with each put request.  Else apply all values simultaneously (asynchronously)
+
+        Returns
+
+        Parameters
+        ----------
+        entry : Union[Setpoint, Snapshot]
+            The entry to apply values from
+        sequential : bool, optional
+            Whether to apply values sequentially, by default False
+
+        Returns
+        -------
+        Optional[List[TaskStatus]]
+            TaskStatus(es) for each value applied.
+        """
+        if not isinstance(entry, (Setpoint, Snapshot)):
+            logger.info("Entries must be a Snapshot or Setpoint")
+            return
+
+        if isinstance(entry, Setpoint):
+            return [self.cl.put(entry.pv_name, entry.data)]
+
+        # Gather pv-value list and apply at once
+        status_list = []
+        pv_list, data_list = self._gather_data(entry)
+        if sequential:
+            for pv, data in zip(pv_list, data_list):
+                logger.debug(f'Putting {pv} = {data}')
+                status: TaskStatus = self.cl.put(pv, data)
+                if status.exception():
+                    logger.warning(f"Failed to put {pv} = {data}, "
+                                   "terminating put sequence")
+                    return
+
+                status_list.append(status)
+        else:
+            return self.cl.put(pv_list, data_list)
+
+    def _gather_data(
+        self,
+        entry: Union[Setpoint, Snapshot, UUID],
+        pv_list: Optional[List[str]] = None,
+        data_list: Optional[List[Any]] = None
+    ) -> Optional[tuple[List[str], List[Any]]]:
+        """
+        Gather writable pv name - data pairs recursively.
+        If pv_list and data_list are provided, gathered data will be added to
+        these lists in-place. If both lists are omitted, this function will return
+        the two lists after gathering.
+
+        Queries the backend to fill any UUID values found.
+
+        Parameters
+        ----------
+        entry : Union[Setpoint, Snapshot, UUID]
+            Entry to gather writable data from
+        pv_list : Optional[List[str]], optional
+            List of addresses to write data to, by default None
+        data_list : Optional[List[Any]], optional
+            List of data to write to addresses in ``pv_list``, by default None
+
+        Returns
+        -------
+        Optional[tuple[List[str], List[Any]]]
+            the filled pv_list and data_list
+        """
+        top_level = False
+        if (pv_list is None) and (data_list is None):
+            pv_list = []
+            data_list = []
+            top_level = True
+        elif (pv_list is None) or (data_list is None):
+            raise ValueError(
+                "Arguments pv_list and data_list must either both be provided "
+                "or both omitted."
+            )
+
+        if isinstance(entry, Snapshot):
+            for child in entry.children:
+                self._gather_data(child, pv_list, data_list)
+        elif isinstance(entry, UUID):
+            child_entry = self.backend.get_entry(entry)
+            self._gather_data(child_entry, pv_list, data_list)
+        elif isinstance(entry, Setpoint):
+            pv_list.append(entry.pv_name)
+            data_list.append(entry.data)
+
+        # Readbacks are not writable, and are not gathered
+
+        if top_level:
+            return pv_list, data_list
 
     def validate(self, entry: Entry):
         """

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -51,8 +51,6 @@ class Client:
         If ``sequential`` is True, apply values in ``entry`` in sequence, blocking
         with each put request.  Else apply all values simultaneously (asynchronously)
 
-        Returns
-
         Parameters
         ----------
         entry : Union[Setpoint, Snapshot]

--- a/superscore/control_layers/__init__.py
+++ b/superscore/control_layers/__init__.py
@@ -1,1 +1,2 @@
 from .core import ControlLayer  # noqa
+from .status import TaskStatus  # noqa

--- a/superscore/control_layers/core.py
+++ b/superscore/control_layers/core.py
@@ -145,7 +145,7 @@ class ControlLayer:
             status = self._put_one(address, value)
             if cb is not None:
                 status.add_callback(cb)
-            await status.task
+            await asyncio.gather(status, return_exceptions=True)
             return status
 
         return asyncio.run(status_coro())
@@ -185,7 +185,7 @@ class ControlLayer:
                     status.add_callback(c)
 
                 statuses.append(status)
-            await asyncio.gather(*[s.task for s in statuses])
+            await asyncio.gather(*statuses, return_exceptions=True)
             return statuses
 
         return asyncio.run(status_coros())
@@ -193,7 +193,7 @@ class ControlLayer:
     @TaskStatus.wrap
     async def _put_one(self, address: str, value: Any):
         """
-        Base async get function.  Use this to construct higher-level get methods
+        Base async put function.  Use this to construct higher-level put methods
         """
         shim = self.shim_from_pv(address)
         await shim.put(address, value)

--- a/superscore/tests/conftest.py
+++ b/superscore/tests/conftest.py
@@ -1,12 +1,14 @@
 import shutil
 from pathlib import Path
 from typing import List
+from unittest.mock import MagicMock
 
 import pytest
 
 from superscore.backends.core import _Backend
 from superscore.backends.filestore import FilestoreBackend
 from superscore.backends.test import TestBackend
+from superscore.client import Client
 from superscore.control_layers._base_shim import _BaseShim
 from superscore.control_layers.core import ControlLayer
 from superscore.model import (Collection, Parameter, Readback, Root, Setpoint,
@@ -697,3 +699,28 @@ def dummy_cl() -> ControlLayer:
     cl.shims['ca'] = DummyShim()
     cl.shims['pva'] = DummyShim()
     return cl
+
+
+@pytest.fixture(scope='function')
+def mock_backend() -> _Backend:
+    bk = _Backend()
+    bk.delete_entry = MagicMock()
+    bk.save_entry = MagicMock()
+    bk.get_entry = MagicMock()
+    bk.search = MagicMock()
+    bk.update_entry = MagicMock()
+
+
+class MockTaskStatus:
+    def exception(self):
+        return None
+
+    @property
+    def done(self):
+        return True
+
+
+@pytest.fixture(scope='function')
+def mock_client(mock_backend: _Backend) -> Client:
+    client = Client(backend=mock_backend)
+    return client

--- a/superscore/tests/test_cl.py
+++ b/superscore/tests/test_cl.py
@@ -38,9 +38,11 @@ def test_fail(dummy_cl):
     mock_ca_put = AsyncMock(side_effect=ValueError)
     dummy_cl.shims['ca'].put = mock_ca_put
 
-    # exceptions get passed through the control layer
-    with pytest.raises(ValueError):
-        dummy_cl.put("THAT:PV", 4)
+    # exceptions get captured in status object
+    status = dummy_cl.put("THAT:PV", 4)
+    assert isinstance(status.exception(), ValueError)
+
+    assert mock_ca_put.called
 
 
 def test_put_callback(dummy_cl):

--- a/superscore/tests/test_client.py
+++ b/superscore/tests/test_client.py
@@ -1,0 +1,21 @@
+from unittest.mock import patch
+
+from superscore.client import Client
+from superscore.model import Root
+
+from .conftest import MockTaskStatus
+
+
+@patch('superscore.control_layers.core.ControlLayer.put')
+def test_apply(put_mock, mock_client: Client, sample_database: Root):
+    put_mock.return_value = MockTaskStatus()
+    snap = sample_database.entries[3]
+    mock_client.apply(snap)
+    assert put_mock.call_count == 1
+    call_args = put_mock.call_args[0]
+    assert len(call_args[0]) == len(call_args[1]) == 3
+
+    put_mock.reset_mock()
+
+    mock_client.apply(snap, sequential=True)
+    assert put_mock.call_count == 3

--- a/superscore/tests/test_status.py
+++ b/superscore/tests/test_status.py
@@ -40,7 +40,7 @@ async def test_status_fail(failing_coroutine):
     with pytest.raises(ValueError):
         await status
 
-    assert type(status.exception()) == ValueError
+    assert isinstance(status.exception(), ValueError)
 
 
 async def test_status_wrap():
@@ -50,5 +50,5 @@ async def test_status_wrap():
 
     st = coro_status()
     assert isinstance(st, TaskStatus)
-    await st.task
+    await st
     assert st.done


### PR DESCRIPTION
## Description
- Adds Client.apply method, for writing values to the control system
- Adjusts use of `TaskStatus` to actually capture exceptions, instead of propagating them

## Motivation and Context
closes #7 

Assorted thoughts
- In the future it may be worth validating these Entries before applying them
- `TaskStatus` was built to hold exceptions raised in the coroutines they wrap, but were propagating them to the calling context.  This was caused by our used of `asyncio.gather`, which needed the `return_exceptions=True` kwarg.  `asyncio` has various ways of handling and propagating exceptions, we just needed to choose the right one for us.

## How Has This Been Tested?
Basic unit test added

## Where Has This Been Documented?
This PR, docstrings etc

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
