### PR TITLE
ENH: Add ability to instantiate Client from configuration file

### DIFF
--- a/docs/source/upcoming_release_notes/54-enh_config_client.rst
+++ b/docs/source/upcoming_release_notes/54-enh_config_client.rst
@@ -1,0 +1,22 @@
+54 enh_config_client
+####################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Adds ability for Client to search for configuration files, and load settings from them.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/superscore/backends/__init__.py
+++ b/superscore/backends/__init__.py
@@ -1,0 +1,38 @@
+__all__ = ['BACKENDS']
+
+import logging
+from typing import Dict
+
+from .core import _Backend
+
+logger = logging.getLogger(__name__)
+
+
+def _get_backend(backend: str) -> _Backend:
+    if backend == 'filestore':
+        from .filestore import FilestoreBackend
+        return FilestoreBackend
+    if backend == 'test':
+        from .test import TestBackend
+        return TestBackend
+
+    raise ValueError(f"Unknown backend {backend}")
+
+
+def _get_backends() -> Dict[str, _Backend]:
+    backends = {}
+
+    try:
+        backends['filestore'] = _get_backend('filestore')
+    except ImportError as ex:
+        logger.debug(f"Filestore Backend unavailable: {ex}")
+
+    try:
+        backends['test'] = _get_backend('test')
+    except ImportError as ex:
+        logger.debug(f"Test Backend unavailable: {ex}")
+
+    return backends
+
+
+BACKENDS = _get_backends()

--- a/superscore/backends/test.py
+++ b/superscore/backends/test.py
@@ -1,7 +1,7 @@
 """
 Backend that manipulates Entries in-memory for testing purposes.
 """
-from typing import List
+from typing import List, Optional
 from uuid import UUID
 
 from superscore.backends.core import _Backend
@@ -12,8 +12,11 @@ from superscore.model import Entry, Nestable
 
 class TestBackend(_Backend):
     """Backend that manipulates Entries in-memory, for testing purposes."""
-    def __init__(self, data: List[Entry]):
-        self.data = data
+    def __init__(self, data: Optional[List[Entry]] = None):
+        if data is None:
+            self.data = []
+        else:
+            self.data = data
 
     def save_entry(self, entry: Entry) -> None:
         try:

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -35,6 +35,39 @@ class Client:
 
     @classmethod
     def from_config(cls, cfg: Path = None):
+        """
+        Create a client from the configuration file specification.
+
+        Configuration file should be of an "ini" format, along the lines of:
+
+        .. code::
+
+            [backend]
+            type = filestore
+            path = ./db/filestore.json
+
+            [control_layer]
+            ca = true
+            pva = true
+
+        The ``backend`` section has one special key ("type"), and the rest of the
+        settings are passed to the appropriate ``_Backend`` as keyword arguments.
+
+        The ``control_layer`` section has a key-value pair for each available shim.
+        The ``ControlLayer`` object will be created with all the valid shims with
+        True values.
+
+        Parameters
+        ----------
+        cfg : Path, optional
+            Path to a configuration file, by default None.  If omitted,
+            :meth:`.find_config` will be used to find one
+
+        Raises
+        ------
+        RuntimeError
+            If a configuration file cannot be found
+        """
         if not cfg:
             cfg = cls.find_config()
         if not os.path.exists(cfg):
@@ -68,7 +101,22 @@ class Client:
 
     @staticmethod
     def find_config() -> Path:
-        """search the locations and stuff"""
+        """
+        Search for a ``superscore`` configuation file.  Searches in the following
+        locations in order for a file named "superscore.cfg":
+        - environment variable ``$SUPERSCORE_CFG`` (a full path)
+        - folder set in environment variable ``$XDG_CONFIG_HOME``
+
+        Returns
+        -------
+        path : str
+            Absolute path to the configuration file
+
+        Raises
+        ------
+        OSError
+            If no configuration file can be found by the described methodology
+        """
         # Point to with an environment variable
         if os.environ.get('SUPERSCORE_CFG', False):
             happi_cfg = os.environ.get('SUPERSCORE_CFG')
@@ -80,7 +128,7 @@ class Client:
             config_dirs = [os.environ.get('XDG_CONFIG_HOME', "."),
                            os.path.expanduser('~/.config'),]
             for directory in config_dirs:
-                logger.debug('Searching for SuperScore config in %s', directory)
+                logger.debug('Searching for superscore config in %s', directory)
                 for path in ('.superscore.cfg', 'superscore.cfg'):
                     full_path = os.path.join(directory, path)
 
@@ -88,7 +136,7 @@ class Client:
                         logger.debug("Found configuration file at %r", full_path)
                         return full_path
         # If found nothing
-        raise OSError("No SuperScore configuration file found. Check SUPERSCORE_CFG.")
+        raise OSError("No superscore configuration file found. Check SUPERSCORE_CFG.")
 
     def search(self, **post) -> Generator[Entry, None, None]:
         """Search by key-value pair.  Can search by any field, including id"""

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -92,7 +92,6 @@ class Client:
             shim_choices = [val for val, enabled
                             in cfg_parser["control_layer"].items()
                             if enabled]
-            print(shim_choices)
             control_layer = ControlLayer(shims=shim_choices)
         else:
             control_layer = ControlLayer()
@@ -103,9 +102,10 @@ class Client:
     def find_config() -> Path:
         """
         Search for a ``superscore`` configuation file.  Searches in the following
-        locations in order for a file named "superscore.cfg":
-        - environment variable ``$SUPERSCORE_CFG`` (a full path)
-        - folder set in environment variable ``$XDG_CONFIG_HOME``
+        locations in order
+        - ``$SUPERSCORE_CFG`` (a full path to a config file)
+        - ``$XDG_CONFIG_HOME/{superscore.cfg, .superscore.cfg}`` (either filename)
+        - ``~/.config/{superscore.cfg, .superscore.cfg}``
 
         Returns
         -------

--- a/superscore/control_layers/core.py
+++ b/superscore/control_layers/core.py
@@ -4,12 +4,17 @@ and dispatches to various shims depending on the context.
 """
 import asyncio
 from functools import singledispatchmethod
-from typing import Any, Callable, Dict, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from superscore.control_layers.status import TaskStatus
 
 from ._aioca import AiocaShim
 from ._base_shim import _BaseShim
+
+# available communication shim layers
+SHIMS = {
+    'ca': AiocaShim()
+}
 
 
 class ControlLayer:
@@ -19,10 +24,13 @@ class ControlLayer:
     """
     shims: Dict[str, _BaseShim]
 
-    def __init__(self, *args, **kwargs):
-        self.shims = {
-            'ca': AiocaShim(),
-        }
+    def __init__(self, *args, shims: Optional[List[str]] = None, **kwargs):
+        if shims is None:
+            # load all available shims
+            self.shims = SHIMS
+        else:
+            self.shims = {key: shim for key, shim in SHIMS.items() if key in shims}
+            print(self.shims)
 
     def shim_from_pv(self, address: str) -> _BaseShim:
         """

--- a/superscore/control_layers/core.py
+++ b/superscore/control_layers/core.py
@@ -3,6 +3,7 @@ Main control layer objects.  Exposes basic communication operations,
 and dispatches to various shims depending on the context.
 """
 import asyncio
+import logging
 from functools import singledispatchmethod
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -10,6 +11,8 @@ from superscore.control_layers.status import TaskStatus
 
 from ._aioca import AiocaShim
 from ._base_shim import _BaseShim
+
+logger = logging.getLogger(__name__)
 
 # available communication shim layers
 SHIMS = {
@@ -28,8 +31,12 @@ class ControlLayer:
         if shims is None:
             # load all available shims
             self.shims = SHIMS
+            logger.debug('No shims specified, loading all available communication '
+                         f'shims: {list(self.shims.keys())}')
         else:
             self.shims = {key: shim for key, shim in SHIMS.items() if key in shims}
+            logger.debug('Loaded valid shims from the requested list: '
+                         f'{list(self.shims.keys())}')
 
     def shim_from_pv(self, address: str) -> _BaseShim:
         """

--- a/superscore/control_layers/core.py
+++ b/superscore/control_layers/core.py
@@ -30,7 +30,6 @@ class ControlLayer:
             self.shims = SHIMS
         else:
             self.shims = {key: shim for key, shim in SHIMS.items() if key in shims}
-            print(self.shims)
 
     def shim_from_pv(self, address: str) -> _BaseShim:
         """

--- a/superscore/tests/config.cfg
+++ b/superscore/tests/config.cfg
@@ -1,0 +1,7 @@
+[backend]
+type = filestore
+path = ./db/filestore.json
+
+[control_layer]
+ca = true
+pva = true

--- a/superscore/tests/test_client.py
+++ b/superscore/tests/test_client.py
@@ -1,9 +1,42 @@
+import os
+from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
+from superscore.backends.filestore import FilestoreBackend
 from superscore.client import Client
 from superscore.model import Root
 
 from .conftest import MockTaskStatus
+
+SAMPLE_CFG = Path(__file__).parent / 'config.cfg'
+
+
+@pytest.fixture(scope='function')
+def xdg_config_patch(tmp_path):
+    config_home = tmp_path / 'xdg_config_home'
+    config_home.mkdir()
+    return config_home
+
+
+@pytest.fixture(scope='function')
+def sscore_cfg(xdg_config_patch: Path):
+    # patch config discovery paths
+    xdg_cfg = os.environ.get("XDG_CONFIG_HOME", '')
+    sscore_cfg = os.environ.get("SUPERSCORE_CFG", '')
+
+    os.environ['XDG_CONFIG_HOME'] = str(xdg_config_patch)
+    os.environ['SUPERSCORE_CFG'] = ''
+
+    sscore_cfg_path = xdg_config_patch / "superscore.cfg"
+    sscore_cfg_path.symlink_to(SAMPLE_CFG)
+
+    yield str(sscore_cfg_path)
+
+    # reset env vars
+    os.environ["SUPERSCORE_CFG"] = str(sscore_cfg)
+    os.environ["XDG_CONFIG_HOME"] = xdg_cfg
 
 
 @patch('superscore.control_layers.core.ControlLayer.put')
@@ -19,3 +52,9 @@ def test_apply(put_mock, mock_client: Client, sample_database: Root):
 
     mock_client.apply(snap, sequential=True)
     assert put_mock.call_count == 3
+
+
+def test_from_cfg(sscore_cfg: str):
+    client = Client.from_config()
+    assert isinstance(client.backend, FilestoreBackend)
+    assert 'ca' in client.cl.shims

--- a/superscore/tests/test_client.py
+++ b/superscore/tests/test_client.py
@@ -58,3 +58,11 @@ def test_from_cfg(sscore_cfg: str):
     client = Client.from_config()
     assert isinstance(client.backend, FilestoreBackend)
     assert 'ca' in client.cl.shims
+
+
+def test_find_config(sscore_cfg: str):
+    assert sscore_cfg == Client.find_config()
+
+    # explicit SUPERSCORE_CFG env var supercedes XDG_CONFIG_HOME
+    os.environ['SUPERSCORE_CFG'] = 'other/cfg'
+    assert 'other/cfg' == Client.find_config()


### PR DESCRIPTION
## Description
- Adds ability for `Client` to search for configuration files, and load settings from them.
  - Searches, in order:
    - `$SUPERSCORE_CFG` environment variable
    - `$XDG_CONFIG_HOME` directory, for files named `superscore.cfg` or `.superscore.cfg`
    - `~/.config` directory, for files named `superscore.cfg` or `.superscore.cfg`

## Motivation and Context
closes #8 

## How Has This Been Tested?
Added a couple tests.  Otherwise interactive tests

## Where Has This Been Documented?
This PR

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
