### PR TITLE
GUI / ENH: Add search page, augment search terms

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - apischema
     - pcdsutils
     - pyqt
+    - python-dateutil
     - qtpy
 
 test:

--- a/docs/source/upcoming_release_notes/56-gui_search_page.rst
+++ b/docs/source/upcoming_release_notes/56-gui_search_page.rst
@@ -1,0 +1,23 @@
+56 gui_search_page
+##################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Adds SearchPage for filtering and viewing Entry objects
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Allow relative paths for backend filestore location
+- Adjust FilestoreBackend search method to permit some special arguments and special search types.
+
+Contributors
+------------
+- tangkong

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ aioca
 apischema
 pcdsutils
 PyQt5
+python-dateutil
 qtpy

--- a/superscore/backends/filestore.py
+++ b/superscore/backends/filestore.py
@@ -295,9 +295,20 @@ class FilestoreBackend(_Backend):
                 match_found = True
                 for key, value in search_kwargs.items():
                     # specific type handling, assuming is tuple
-                    if "entry_type" in search_kwargs:
+                    if key == "entry_type":
                         if not isinstance(entry, search_kwargs["entry_type"]):
                             match_found = False
+
+                    elif key == "start_time":
+                        if value > entry.creation_time:
+                            match_found = False
+                    elif key == "end_time":
+                        if entry.creation_time > value:
+                            match_found = False
+
+                    # TODO: search for child pvs?
+
+                    # plain key-value match
                     else:
                         entry_value = getattr(entry, key, None)
                         if isinstance(value, tuple):

--- a/superscore/backends/filestore.py
+++ b/superscore/backends/filestore.py
@@ -286,13 +286,28 @@ class FilestoreBackend(_Backend):
     def search(self, **search_kwargs) -> Generator[Entry, None, None]:
         """
         Search for an entry that matches ``search_kwargs``.
+        Keys are attributes on `Entry` subclasses
+        Values can be either a single value to match or a tuple of valid values
         Currently does not support partial matches.
         """
         with self._load_and_store_context() as db:
             for entry in db.values():
-                match = (getattr(entry, key, None) == value
-                         for key, value in search_kwargs.items())
-                if all(match):
+                match_found = True
+                for key, value in search_kwargs.items():
+                    # specific type handling, assuming is tuple
+                    if "entry_type" in search_kwargs:
+                        if not isinstance(entry, search_kwargs["entry_type"]):
+                            match_found = False
+                    else:
+                        entry_value = getattr(entry, key, None)
+                        if isinstance(value, tuple):
+                            matched = entry_value in value
+                        else:
+                            matched = entry_value == value
+
+                        match_found = match_found and matched
+
+                if match_found:
                     yield entry
 
     @contextlib.contextmanager

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -11,6 +11,7 @@ from superscore.backends.core import _Backend
 from superscore.control_layers import ControlLayer
 from superscore.control_layers.status import TaskStatus
 from superscore.model import Entry, Setpoint, Snapshot
+from superscore.utils import build_abs_path
 
 logger = logging.getLogger(__name__)
 
@@ -85,6 +86,8 @@ class Client:
                       in cfg_parser["backend"].items()
                       if key != "type"}
             backend_class = get_backend(backend_type)
+            if 'path' in kwargs:
+                kwargs['path'] = build_abs_path(Path(cfg).parent, kwargs['path'])
             backend = backend_class(**kwargs)
         else:
             logger.warning('No backend specified, loading an empty test backend')

--- a/superscore/tests/test_backend.py
+++ b/superscore/tests/test_backend.py
@@ -5,7 +5,7 @@ import pytest
 from superscore.backends.core import _Backend
 from superscore.errors import (BackendError, EntryExistsError,
                                EntryNotFoundError)
-from superscore.model import Collection, Parameter
+from superscore.model import Collection, Parameter, Snapshot
 
 
 class TestTestBackend:
@@ -89,6 +89,12 @@ def test_search_entry(backends: _Backend):
         uuid=UUID('ecb42cdb-b703-4562-86e1-45bd67a2ab1a'), data=2
     )
     assert len(list(results)) == 1
+
+    results = backends.search(entry_type=Snapshot,)
+    assert len(list(results)) == 1
+
+    results = backends.search(entry_type=(Snapshot, Collection))
+    assert len(list(results)) == 2
 
 
 @pytest.mark.parametrize('backends', [0], indirect=True)

--- a/superscore/tests/test_page.py
+++ b/superscore/tests/test_page.py
@@ -1,12 +1,47 @@
 """Largely smoke tests for various pages"""
 
+from typing import List
+
+import pytest
 from pytestqt.qtbot import QtBot
 
+from superscore.client import Client
 from superscore.model import Collection
+from superscore.widgets.core import DataWidget
 from superscore.widgets.page.entry import CollectionPage
+from superscore.widgets.page.search import SearchPage
 
 
-def test_collection_page(qtbot: QtBot):
+@pytest.fixture(scope='function')
+def collection_page(qtbot: QtBot):
     data = Collection()
     page = CollectionPage(data=data)
     qtbot.addWidget(page)
+    return page
+
+
+@pytest.fixture(scope='function')
+def search_page(qtbot: QtBot, mock_client: Client):
+    page = SearchPage(client=mock_client)
+    qtbot.addWidget(page)
+    return page
+
+
+@pytest.fixture(scope='function')
+def test_pages(
+    collection_page: CollectionPage,
+    search_page: SearchPage,
+) -> List[DataWidget]:
+    return [collection_page, search_page,]
+
+
+@pytest.fixture(scope='function')
+def pages(request, test_pages: List[DataWidget]):
+    i = request.param
+    return test_pages[i]
+
+
+@pytest.mark.parametrize('pages', [0, 1], indirect=True)
+def test_page_smoke(pages):
+    """smoke test, just create each page and see if they fail"""
+    print(type(pages))

--- a/superscore/ui/main_window.ui
+++ b/superscore/ui/main_window.ui
@@ -14,19 +14,55 @@
    <string>MainWindow</string>
   </property>
   <widget class="QWidget" name="central_widget">
-   <layout class="QVBoxLayout" name="verticalLayout">
+   <layout class="QVBoxLayout" name="verticalLayout_2">
     <item>
      <widget class="QSplitter" name="splitter">
       <property name="orientation">
        <enum>Qt::Horizontal</enum>
       </property>
-      <widget class="QTreeView" name="tree_view">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
+      <widget class="QWidget" name="">
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <item>
+         <layout class="QHBoxLayout" name="search_hayout">
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QCheckBox" name="checkBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Apply Filter</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="comboBox"/>
+          </item>
+          <item>
+           <widget class="QToolButton" name="toolButton">
+            <property name="text">
+             <string>?</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QTreeView" name="tree_view">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </widget>
       <widget class="QTabWidget" name="tab_widget">
        <property name="sizePolicy">

--- a/superscore/ui/search_page.ui
+++ b/superscore/ui/search_page.ui
@@ -35,7 +35,11 @@
         </widget>
        </item>
        <item>
-        <widget class="QLineEdit" name="name_line_edit"/>
+        <widget class="QLineEdit" name="name_line_edit">
+         <property name="placeholderText">
+          <string>names, comma, separated</string>
+         </property>
+        </widget>
        </item>
        <item>
         <widget class="QLabel" name="type_label">
@@ -59,16 +63,16 @@
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="readback_checkbox">
+        <widget class="QCheckBox" name="setpoint_checkbox">
          <property name="text">
-          <string>Readback</string>
+          <string>Setpoint</string>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QCheckBox" name="setpoint_checkbox">
+        <widget class="QCheckBox" name="readback_checkbox">
          <property name="text">
-          <string>Setpoint</string>
+          <string>Readback</string>
          </property>
         </widget>
        </item>
@@ -80,7 +84,11 @@
         </widget>
        </item>
        <item>
-        <widget class="QLineEdit" name="desc_line_edit"/>
+        <widget class="QLineEdit" name="desc_line_edit">
+         <property name="placeholderText">
+          <string>description</string>
+         </property>
+        </widget>
        </item>
        <item>
         <widget class="QLabel" name="pv_label">
@@ -90,7 +98,11 @@
         </widget>
        </item>
        <item>
-        <widget class="QLineEdit" name="pv_line_edit"/>
+        <widget class="QLineEdit" name="pv_line_edit">
+         <property name="placeholderText">
+          <string>PVS:TO:INCLUDE, COMMA:SEP</string>
+         </property>
+        </widget>
        </item>
        <item>
         <widget class="QLabel" name="time_label">
@@ -118,15 +130,19 @@
           </widget>
          </item>
          <item>
-          <widget class="QDateTimeEdit" name="start_dt_edit"/>
+          <widget class="QDateTimeEdit" name="start_dt_edit">
+           <property name="displayFormat">
+            <string>yyyy/MM/dd hh:mm AP</string>
+           </property>
+           <property name="calendarPopup">
+            <bool>true</bool>
+           </property>
+          </widget>
          </item>
         </layout>
        </item>
        <item>
         <layout class="QHBoxLayout" name="end_dt_hlayout">
-         <property name="topMargin">
-          <number>10</number>
-         </property>
          <item>
           <widget class="QLabel" name="end_time_label">
            <property name="sizePolicy">
@@ -141,7 +157,14 @@
           </widget>
          </item>
          <item>
-          <widget class="QDateTimeEdit" name="end_dt_edit"/>
+          <widget class="QDateTimeEdit" name="end_dt_edit">
+           <property name="displayFormat">
+            <string>yyyy/MM/dd hh:mm AP</string>
+           </property>
+           <property name="calendarPopup">
+            <bool>true</bool>
+           </property>
+          </widget>
          </item>
         </layout>
        </item>

--- a/superscore/ui/search_page.ui
+++ b/superscore/ui/search_page.ui
@@ -1,0 +1,253 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>829</width>
+    <height>538</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="horizontalLayout_2">
+   <item>
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <widget class="QWidget" name="verticalLayoutWidget">
+      <layout class="QVBoxLayout" name="options_vlayout">
+       <item>
+        <widget class="QLabel" name="name_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Entry Name</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="name_line_edit"/>
+       </item>
+       <item>
+        <widget class="QLabel" name="type_label">
+         <property name="text">
+          <string>Entry Type</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="snapshot_checkbox">
+         <property name="text">
+          <string>Snapshot</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="collection_checkbox">
+         <property name="text">
+          <string>Collection</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="readback_checkbox">
+         <property name="text">
+          <string>Readback</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="setpoint_checkbox">
+         <property name="text">
+          <string>Setpoint</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="desc_label">
+         <property name="text">
+          <string>Description / Comment</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="desc_line_edit"/>
+       </item>
+       <item>
+        <widget class="QLabel" name="pv_label">
+         <property name="text">
+          <string>PVs (excluding children)</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="pv_line_edit"/>
+       </item>
+       <item>
+        <widget class="QLabel" name="time_label">
+         <property name="text">
+          <string>Creation time range</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="start_dt_hlayout">
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="start_time_label">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Start:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDateTimeEdit" name="start_dt_edit"/>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="end_dt_hlayout">
+         <property name="topMargin">
+          <number>10</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="end_time_label">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>End:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDateTimeEdit" name="end_dt_edit"/>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="apply_filter_button">
+         <property name="text">
+          <string>Apply Filter</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QSplitter" name="right_splitter">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <widget class="QWidget" name="verticalLayoutWidget_2">
+       <layout class="QVBoxLayout" name="result_vlayout">
+        <item>
+         <layout class="QHBoxLayout" name="filter_summary_hlayout">
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="query_label">
+            <property name="text">
+             <string>Query:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="query_details_label">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QLabel" name="name_subfilter_label">
+            <property name="text">
+             <string>Filter by name:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="name_subfilter_line_edit"/>
+          </item>
+          <item>
+           <widget class="QPushButton" name="save_filter_buton">
+            <property name="text">
+             <string>Save Filter</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="help_button">
+            <property name="text">
+             <string>Help</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QTableView" name="results_table_view"/>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QTableView" name="filter_table_view"/>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/superscore/widgets/page/search.py
+++ b/superscore/widgets/page/search.py
@@ -1,13 +1,15 @@
 """Search page"""
 
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from dateutil import tz
+from PyQt5.QtCore import QModelIndex
+from PyQt5.QtWidgets import QStyleOptionViewItem, QWidget
 from qtpy import QtCore, QtWidgets
 
 from superscore.client import Client
-from superscore.model import Collection, Readback, Setpoint, Snapshot
+from superscore.model import Collection, Entry, Readback, Setpoint, Snapshot
 from superscore.widgets.core import Display
 
 logger = logging.getLogger(__name__)
@@ -41,6 +43,7 @@ class SearchPage(Display, QtWidgets.QWidget):
     def __init__(self, *args, client: Client, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.client = client
+        self.model: Optional[ResultModel] = None
 
         self.type_checkboxes: List[QtWidgets.QCheckBox] = [
             self.snapshot_checkbox, self.collection_checkbox,
@@ -51,7 +54,16 @@ class SearchPage(Display, QtWidgets.QWidget):
     def setup_ui(self) -> None:
         self.start_dt_edit.setDate(QtCore.QDate.currentDate().addDays(-365))
         self.end_dt_edit.setDate(QtCore.QDate.currentDate())
-        self.apply_filter_button.clicked.connect(self._gather_search_terms)
+        self.apply_filter_button.clicked.connect(self.show_current_filter)
+
+        self.model = ResultModel(entries=[])
+        self.results_table_view.setModel(self.model)
+        horiz_header = self.results_table_view.horizontalHeader()
+        horiz_header.setSectionResizeMode(horiz_header.Interactive)
+
+        self.open_delegate = ButtonDelegate(button_text='open me')
+        del_col = len(ResultModel.headers) - 1
+        self.results_table_view.setItemDelegateForColumn(del_col, self.open_delegate)
 
     def _gather_search_terms(self) -> Dict[str, Any]:
         search_kwargs = {}
@@ -91,3 +103,131 @@ class SearchPage(Display, QtWidgets.QWidget):
 
         logger.debug(f'gathered search terms: {search_kwargs}')
         return search_kwargs
+
+    def show_current_filter(self) -> None:
+        # gather filter details
+        search_kwargs = self._gather_search_terms()
+        entries = self.client.search(**search_kwargs)
+
+        # create table
+        self.model = ResultModel(entries=list(entries))
+        self.results_table_view.setModel(self.model)
+
+
+class ResultModel(QtCore.QAbstractTableModel):
+    headers: List[str] = ['Name', 'Type', 'Description', 'Created', 'Open']
+
+    def __init__(self, *args, entries: List[Entry] = None, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.entries: List[Entry] = entries or []
+
+    def data(self, index: QtCore.QModelIndex, role: int) -> Any:
+        """
+        Returns the data stored under the given role for the item
+        referred to by the index.
+
+        Parameters
+        ----------
+        index : QtCore.QModelIndex
+            An index referring to a cell of the TableView
+        role : int
+            The requested data role.
+
+        Returns
+        -------
+        Any
+            the requested data
+        """
+        entry: Entry = self.entries[index.row()]
+
+        # Special handling for open button delegate
+        if index.column() == (len(self.headers) - 1):
+            if role in (QtCore.Qt.DisplayRole, QtCore.Qt.EditRole):
+                return 'open'
+
+        if role != QtCore.Qt.DisplayRole:
+            # table is read only
+            return QtCore.QVariant()
+
+        if index.column() == 0:  # name column, no edit permissions
+            name_text = getattr(entry, 'title', getattr(entry, 'pv_name', '<N/A>'))
+            return name_text
+        elif index.column() == 1:  # Type
+            return type(entry).__name__
+        elif index.column() == 2:  # Description
+            return getattr(entry, 'description', '<no desc>')
+        elif index.column() == 3:  # Creation time
+            return entry.creation_time.strftime('%Y/%m/%d %H:%M')
+
+        # if nothing is found, return invalid QVariant
+        return QtCore.QVariant()
+
+    def rowCount(self, index):
+        return len(self.entries)
+
+    def columnCount(self, index):
+        return len(self.headers)
+
+    def headerData(
+        self,
+        section: int,
+        orientation: QtCore.Qt.Orientation,
+        role: int
+    ) -> Any:
+        """
+        Returns the header data for the model.
+        Currently only displays horizontal header data
+        """
+        if role != QtCore.Qt.DisplayRole:
+            return
+
+        if orientation == QtCore.Qt.Horizontal:
+            return self.headers[section]
+
+    def flags(self, index: QtCore.QModelIndex) -> QtCore.Qt.ItemFlag:
+        """
+        Returns the item flags for the given ``index``.  The returned
+        item flag controls what behaviors the item supports.
+
+        Parameters
+        ----------
+        index : QtCore.QModelIndex
+            the index referring to a cell of the TableView
+
+        Returns
+        -------
+        QtCore.Qt.ItemFlag
+            the ItemFlag corresponding to the cell
+        """
+        if (index.column() == len(self.headers) - 1):
+            return QtCore.Qt.ItemIsEditable | QtCore.Qt.ItemIsEnabled
+        else:
+            return QtCore.Qt.ItemIsEnabled
+
+
+class ButtonDelegate(QtWidgets.QStyledItemDelegate):
+    clicked = QtCore.Signal(int)
+
+    def __init__(self, *args, button_text: str = '', **kwargs):
+        self.button_text = button_text
+        super().__init__(*args, **kwargs)
+
+    def createEditor(
+        self,
+        parent: QtWidgets.QWidget,
+        option,
+        index: QtCore.QModelIndex
+    ) -> QtWidgets.QWidget:
+        button = QtWidgets.QPushButton(self.button_text, parent)
+        button.clicked.connect(
+            lambda _, row=index.row(): self.clicked.emit(row)
+        )
+        return button
+
+    def updateEditorGeometry(
+        self,
+        editor: QWidget,
+        option: QStyleOptionViewItem,
+        index: QModelIndex
+    ) -> None:
+        return editor.setGeometry(option.rect)

--- a/superscore/widgets/page/search.py
+++ b/superscore/widgets/page/search.py
@@ -16,6 +16,14 @@ logger = logging.getLogger(__name__)
 
 
 class SearchPage(Display, QtWidgets.QWidget):
+    """
+    Widget for searching and displaying Entry's.  Contains a variety of filter
+    option input widgets, a sortable table view, and a filter management table.
+
+    TODO: Implement filters (saving/loading)
+    TODO: string-ified search query
+    TODO: integration with global tree-view
+    """
     filename = 'search_page.ui'
 
     # Left splitter, filter options select
@@ -52,10 +60,12 @@ class SearchPage(Display, QtWidgets.QWidget):
         self.setup_ui()
 
     def setup_ui(self) -> None:
+        # set up filter option widgets
         self.start_dt_edit.setDate(QtCore.QDate.currentDate().addDays(-365))
         self.end_dt_edit.setDate(QtCore.QDate.currentDate())
         self.apply_filter_button.clicked.connect(self.show_current_filter)
 
+        # set up filter table view
         self.model = ResultModel(entries=[])
         self.proxy_model = ResultFilterProxyModel()
         self.proxy_model.setSourceModel(self.model)
@@ -110,6 +120,9 @@ class SearchPage(Display, QtWidgets.QWidget):
         return search_kwargs
 
     def show_current_filter(self) -> None:
+        """
+        Gather filter options and update source model with valid entries
+        """
         # gather filter details
         search_kwargs = self._gather_search_terms()
         entries = self.client.search(**search_kwargs)
@@ -246,8 +259,8 @@ class ButtonDelegate(QtWidgets.QStyledItemDelegate):
 
 class ResultFilterProxyModel(QtCore.QSortFilterProxyModel):
     """
-    Filter proxy model specifically for ResultModel.
-    Combines multiple filter conditions.
+    Filter proxy model specifically for ResultModel.  Enables per-column sorting
+    and filtering table contents by name.
     """
 
     name_regexp: QtCore.QRegularExpression

--- a/superscore/widgets/page/search.py
+++ b/superscore/widgets/page/search.py
@@ -1,0 +1,93 @@
+"""Search page"""
+
+import logging
+from typing import Any, Dict, List
+
+from dateutil import tz
+from qtpy import QtCore, QtWidgets
+
+from superscore.client import Client
+from superscore.model import Collection, Readback, Setpoint, Snapshot
+from superscore.widgets.core import Display
+
+logger = logging.getLogger(__name__)
+
+
+class SearchPage(Display, QtWidgets.QWidget):
+    filename = 'search_page.ui'
+
+    # Left splitter, filter options select
+    name_line_edit: QtWidgets.QLineEdit
+    snapshot_checkbox: QtWidgets.QCheckBox
+    collection_checkbox: QtWidgets.QCheckBox
+    setpoint_checkbox: QtWidgets.QCheckBox
+    readback_checkbox: QtWidgets.QCheckBox
+    pv_line_edit: QtWidgets.QLineEdit
+    desc_line_edit: QtWidgets.QLineEdit
+    start_dt_edit: QtWidgets.QDateTimeEdit
+    end_dt_edit: QtWidgets.QDateTimeEdit
+
+    apply_filter_button: QtWidgets.QPushButton
+
+    # Right splitter, filter results view
+    name_subfilter_line_edit: QtWidgets.QLineEdit
+    query_details_label: QtWidgets.QLabel
+    save_filter_button: QtWidgets.QPushButton
+    help_button: QtWidgets.QPushButton  # maybe a toolbutton for widget pop-out
+
+    filter_table_view: QtWidgets.QTableView
+    results_table_view: QtWidgets.QTableView
+
+    def __init__(self, *args, client: Client, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.client = client
+
+        self.type_checkboxes: List[QtWidgets.QCheckBox] = [
+            self.snapshot_checkbox, self.collection_checkbox,
+            self.setpoint_checkbox, self.readback_checkbox,
+        ]
+        self.setup_ui()
+
+    def setup_ui(self) -> None:
+        self.start_dt_edit.setDate(QtCore.QDate.currentDate().addDays(-365))
+        self.end_dt_edit.setDate(QtCore.QDate.currentDate())
+        self.apply_filter_button.clicked.connect(self._gather_search_terms)
+
+    def _gather_search_terms(self) -> Dict[str, Any]:
+        search_kwargs = {}
+
+        # type
+        entry_type_list = []
+        for checkbox, entry_type in zip(
+            self.type_checkboxes,
+            (Snapshot, Collection, Setpoint, Readback)
+        ):
+            if checkbox.isChecked():
+                entry_type_list.append(entry_type)
+
+        if entry_type_list:
+            search_kwargs["entry_type"] = tuple(entry_type_list)
+
+        # name
+        name = self.name_line_edit.text()
+        if name:
+            search_kwargs['title'] = tuple(n.strip() for n in name.split(','))
+
+        # description
+        desc = self.desc_line_edit.text()
+        if desc:
+            search_kwargs['description'] = desc
+
+        # TODO: sort out PVs
+        pvs = self.pv_line_edit.text()
+        if pvs:
+            search_kwargs['pvs'] = tuple(pv.strip() for pv in pvs.split(','))
+
+        # time
+        start_dt = self.start_dt_edit.dateTime().toPyDateTime()
+        search_kwargs['start_time'] = start_dt.astimezone(tz.UTC)
+        end_dt = self.end_dt_edit.dateTime().toPyDateTime()
+        search_kwargs['end_time'] = end_dt.astimezone(tz.UTC)
+
+        logger.debug(f'gathered search terms: {search_kwargs}')
+        return search_kwargs


### PR DESCRIPTION
## Description
- adds a first pass at a search page
- adjusts backend search method to accept search terms that aren't simply key-value matches.  Including:
  - Entry type match
  - date range (start, end date)

TO-DO (in later PRs)
- [ ] wire up buttons from top-level tree view #60 
- [ ] figure out if we're saving filters, and if so where #59 
- [ ] Consider further adjustments to search methods #61 
  - [ ] make filtering on substrings the default method for string-fields / tags?
- [ ] wire up open-page button #62 

## Motivation and Context
Moving toward #45 

## How Has This Been Tested?
interactively

## Where Has This Been Documented?
This PR

![image](https://github.com/user-attachments/assets/9d40d2e6-db5e-4e13-952d-3e919f5c2b89)


## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
