### PR TITLE
ENH: Implement snapshot saving

### DIFF
--- a/docs/source/upcoming_release_notes/57-snapshot_saving.rst
+++ b/docs/source/upcoming_release_notes/57-snapshot_saving.rst
@@ -1,0 +1,23 @@
+57 snapshot saving
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- ability to save Snapshots for a Collection
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- generalized Client._gather_data to work on any type of Entry
+- made Client._gather_data iterative rather than recursive to simplify the conditional logic
+
+Contributors
+------------
+- shilorigins

--- a/superscore/control_layers/core.py
+++ b/superscore/control_layers/core.py
@@ -4,6 +4,7 @@ and dispatches to various shims depending on the context.
 """
 import asyncio
 import logging
+from collections.abc import Iterable
 from functools import singledispatchmethod
 from typing import Any, Callable, Dict, List, Optional, Union
 
@@ -99,13 +100,13 @@ class ControlLayer:
         return asyncio.run(self._get_one(address))
 
     @get.register
-    def _get_list(self, address: list) -> Any:
+    def _get_list(self, address: Iterable) -> Any:
         """Synchronously get a list of ``address``"""
         async def gathered_coros():
             coros = []
             for p in address:
                 coros.append(self._get_one(p))
-            return await asyncio.gather(*coros)
+            return await asyncio.gather(*coros, return_exceptions=True)
 
         return asyncio.run(gathered_coros())
 

--- a/superscore/tests/conftest.py
+++ b/superscore/tests/conftest.py
@@ -681,6 +681,27 @@ def parameter_with_readback() -> Parameter:
 
 
 @pytest.fixture(scope='function')
+def setpoint_with_readback() -> Setpoint:
+    """
+    A simple setpoint-readback value pair
+    """
+    readback = Readback(
+        uuid="7b30ddba-9fae-4691-988c-07384c29fe22",
+        pv_name="RBV",
+        description="A readback PV",
+        data=False,
+    )
+    setpoint = Setpoint(
+        uuid="418ed1ab-f1cf-4188-8f4c-ae7cbaf00e6c",
+        pv_name="SET",
+        description="A setpoint PV",
+        data=True,
+        readback=readback,
+    )
+    return setpoint
+
+
+@pytest.fixture(scope='function')
 def filestore_backend(tmp_path: Path) -> FilestoreBackend:
     fp = Path(__file__).parent / 'db' / 'filestore.json'
     tmp_fp = tmp_path / 'tmp_filestore.json'

--- a/superscore/tests/conftest.py
+++ b/superscore/tests/conftest.py
@@ -662,6 +662,25 @@ def sample_database() -> Root:
 
 
 @pytest.fixture(scope='function')
+def parameter_with_readback() -> Parameter:
+    """
+    A simple setpoint-readback parameter pair
+    """
+    readback = Parameter(
+        uuid="64772c61-c117-445b-b0c8-4c17fd1625d9",
+        pv_name="RBV",
+        description="A readback PV",
+    )
+    setpoint = Parameter(
+        uuid="b508344d-1fe9-473b-8d43-9499d0e8e23f",
+        pv_name="SET",
+        description="A setpoint PV",
+        readback=readback,
+    )
+    return setpoint
+
+
+@pytest.fixture(scope='function')
 def filestore_backend(tmp_path: Path) -> FilestoreBackend:
     fp = Path(__file__).parent / 'db' / 'filestore.json'
     tmp_fp = tmp_path / 'tmp_filestore.json'

--- a/superscore/tests/test_client.py
+++ b/superscore/tests/test_client.py
@@ -6,7 +6,8 @@ import pytest
 
 from superscore.backends.filestore import FilestoreBackend
 from superscore.client import Client
-from superscore.model import Root
+from superscore.errors import CommunicationError
+from superscore.model import Parameter, Readback, Root, Setpoint
 
 from .conftest import MockTaskStatus
 
@@ -39,6 +40,21 @@ def sscore_cfg(xdg_config_patch: Path):
     os.environ["XDG_CONFIG_HOME"] = xdg_cfg
 
 
+def test_gather_data(mock_client, sample_database):
+    snapshot = sample_database.entries[3]
+    orig_pv = snapshot.children[0]
+    dup_pv = Setpoint(
+        uuid=orig_pv.uuid,
+        description=orig_pv.description,
+        pv_name=orig_pv.pv_name,
+        data="You shouldn't see this",
+    )
+    snapshot.children.append(dup_pv)
+    pvs, data_list = mock_client._gather_data(snapshot)
+    assert len(pvs) == len(data_list) == 3
+    assert data_list[pvs.index("MY:PREFIX:mtr1.ACCL")] == 2
+
+
 @patch('superscore.control_layers.core.ControlLayer.put')
 def test_apply(put_mock, mock_client: Client, sample_database: Root):
     put_mock.return_value = MockTaskStatus()
@@ -52,6 +68,34 @@ def test_apply(put_mock, mock_client: Client, sample_database: Root):
 
     mock_client.apply(snap, sequential=True)
     assert put_mock.call_count == 3
+
+
+@patch('superscore.control_layers.core.ControlLayer._get_one')
+def test_snap(
+    get_mock,
+    mock_client: Client,
+    sample_database: Root,
+    parameter_with_readback: Parameter
+):
+    coll = sample_database.entries[2]
+    coll.children.append(parameter_with_readback)
+
+    get_mock.side_effect = range(5)
+    snapshot = mock_client.snap(coll)
+    assert get_mock.call_count == 5
+    assert all([snapshot.children[i].data == i for i in range(4)])  # children saved in order
+    setpoint = snapshot.children[-1]
+    assert isinstance(setpoint, Setpoint)
+    assert isinstance(setpoint.readback, Readback)
+    assert setpoint.readback.data == 4  # readback saved after setpoint
+
+
+@patch('superscore.control_layers.core.ControlLayer._get_one')
+def test_snap_exception(get_mock, mock_client: Client, sample_database: Root):
+    coll = sample_database.entries[2]
+    get_mock.side_effect = [0, 1, CommunicationError, 3, 4]
+    snapshot = mock_client.snap(coll)
+    assert snapshot.children[2].data is None
 
 
 def test_from_cfg(sscore_cfg: str):

--- a/superscore/tests/test_client.py
+++ b/superscore/tests/test_client.py
@@ -56,7 +56,7 @@ def test_gather_data(mock_client, sample_database):
 
 
 @patch('superscore.control_layers.core.ControlLayer.put')
-def test_apply(put_mock, mock_client: Client, sample_database: Root):
+def test_apply(put_mock, mock_client: Client, sample_database: Root, setpoint_with_readback):
     put_mock.return_value = MockTaskStatus()
     snap = sample_database.entries[3]
     mock_client.apply(snap)
@@ -68,6 +68,10 @@ def test_apply(put_mock, mock_client: Client, sample_database: Root):
 
     mock_client.apply(snap, sequential=True)
     assert put_mock.call_count == 3
+
+    put_mock.reset_mock()
+    mock_client.apply(setpoint_with_readback, sequential=True)
+    assert put_mock.call_count == 1
 
 
 @patch('superscore.control_layers.core.ControlLayer._get_one')

--- a/superscore/tests/test_model.py
+++ b/superscore/tests/test_model.py
@@ -26,14 +26,16 @@ def test_serialize_snapshot_roundtrip():
     v2 = Setpoint(pv_name="TEST:PV2", description="Second test Value", data=1.8, status=Status.UDF, severity=Severity.INVALID)
     v3 = Setpoint(pv_name="TEST:PV3", description="Third test Value", data="TRIM", status=Status.DISABLE, severity=Severity.NO_ALARM)
     v4 = Setpoint(pv_name="TEST:PV4", description="Fourth test Value", data=False, status=Status.HIGH, severity=Severity.MAJOR)
+    v5 = Setpoint(pv_name="TEST:PV2", description="Fifth test Value", data=None, status=Status.UDF, severity=Severity.INVALID)
     s1 = Snapshot(title="Snapshot 1", description="Snapshot of Inner Collection", children=[v1, v2])
-    s2 = Snapshot(title="Snapshot 2", description="Snapshot of Outer Collection", children=[v3, s1, v4])
+    s2 = Snapshot(title="Snapshot 2", description="Snapshot of Outer Collection", children=[v3, s1, v4, v5])
     serial = apischema.serialize(Snapshot, s2)
     deserialized = apischema.deserialize(Snapshot, serial)
     assert deserialized == s2
     assert deserialized.children[0] == v3
     assert deserialized.children[1] == s1
     assert deserialized.children[2] == v4
+    assert deserialized.children[3] == v5
     assert deserialized.children[1].children[0] == v1
     assert deserialized.children[1].children[1] == v2
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
* Implement `Snapshot` saving (closes #32 )
  * include helper methods `Client._build_snapshot` and `Client._gather_pvs`
* Extend `Client._gather_data` to accept any type of `Entry`, and make iterative rather than recursive
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`Client.snap` itself is simple: it gathers all of the PVs in an entry, adds in the meta PVs, asynchronously fetches data for each PV, and then builds the snapshot. This method is named `snap` because `save` is currently used for the method that writes entries to the backend.

Since we want a function to gather all of the PVs from an entry, I decided to avoid code duplication by adding that functionality to `Client._gather_data`.  This extension needed some messy code to handle all of the parameter permutations, which I was able to simplify by changing the method to be iterative.  I also use `hasattr` rather than type checks to avoid length conditionals.  I included `Client._gather_pvs` as a convenience method.

Fetching the data is straightforward due to `ControlLayer._get_list`.

Building the snapshot uses a simple depth-first process.

### Alternative Designs
One major alternative was to have each `Entry` subclass implement method to gather its PVs. This conflicts with the current system because the entry classes don't have access to the backend to process UUIDs.
  
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New and updated tests in `test_client.py`
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
This PR, docstrings
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
