### PR TITLE
BUG: add a newline at end of filestore json file

### DIFF
--- a/docs/source/upcoming_release_notes/63-bug_fs_newline.rst
+++ b/docs/source/upcoming_release_notes/63-bug_fs_newline.rst
@@ -1,0 +1,22 @@
+63 bug_fs_newline
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Add newline to end of file when writing filestore json
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/superscore/backends/filestore.py
+++ b/superscore/backends/filestore.py
@@ -214,6 +214,7 @@ class FilestoreBackend(_Backend):
         try:
             with open(temp_path, 'w') as fd:
                 json.dump(serialized, fd, indent=2)
+                fd.write('\n')
 
             if os.path.exists(self.path):
                 shutil.copymode(self.path, temp_path)


### PR DESCRIPTION
## Description
Add a blank newline whenever writing the filestore .json file

## Motivation and Context
Stumbled into this.  The json would fail pre-commit checks every time we tried to commit it.   While infrequent this is something that's easily avoided.

Without this, we would fail pre-commit

## How Has This Been Tested?
Interactively

## Where Has This Been Documented?
This PR

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
