### PR TITLE
GUI: Open page method, add some icons

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
     - pcdsutils
     - pyqt
     - python-dateutil
+    - qtawesome
     - qtpy
 
 test:

--- a/docs/source/upcoming_release_notes/64-gui_open_page.rst
+++ b/docs/source/upcoming_release_notes/64-gui_open_page.rst
@@ -1,0 +1,23 @@
+64 gui_open_page
+################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- adds ``Window.open_page(entry)`` for opening an ``Entry`` in a new tab
+- Adds icons to represent various ``Entry`` subclasses
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ apischema
 pcdsutils
 PyQt5
 python-dateutil
+qtawesome
 qtpy

--- a/superscore/tests/test_window.py
+++ b/superscore/tests/test_window.py
@@ -6,5 +6,5 @@ from superscore.widgets.window import Window
 
 def test_main_window(qtbot: QtBot, mock_client: Client):
     """Pass if main window opens successfully"""
-    window = Window(client=Client)
+    window = Window(client=mock_client)
     qtbot.addWidget(window)

--- a/superscore/tests/test_window.py
+++ b/superscore/tests/test_window.py
@@ -1,9 +1,10 @@
 from pytestqt.qtbot import QtBot
 
+from superscore.client import Client
 from superscore.widgets.window import Window
 
 
-def test_main_window(qtbot: QtBot):
+def test_main_window(qtbot: QtBot, mock_client: Client):
     """Pass if main window opens successfully"""
-    window = Window()
+    window = Window(client=Client)
     qtbot.addWidget(window)

--- a/superscore/ui/search_page.ui
+++ b/superscore/ui/search_page.ui
@@ -53,12 +53,18 @@
          <property name="text">
           <string>Snapshot</string>
          </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
        <item>
         <widget class="QCheckBox" name="collection_checkbox">
          <property name="text">
           <string>Collection</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -67,12 +73,18 @@
          <property name="text">
           <string>Setpoint</string>
          </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
        <item>
         <widget class="QCheckBox" name="readback_checkbox">
          <property name="text">
           <string>Readback</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
          </property>
         </widget>
        </item>

--- a/superscore/widgets/page/__init__.py
+++ b/superscore/widgets/page/__init__.py
@@ -1,0 +1,21 @@
+def get_page_icon_map():
+    # Don't pollute the namespace
+    from superscore.model import Collection, Readback, Setpoint, Snapshot
+    from superscore.widgets.page.entry import CollectionPage
+
+    page_map = {
+        Collection: CollectionPage
+    }
+
+    # a list of qtawesome icon names
+    icon_map = {
+        Collection: 'mdi.file-document-multiple',
+        Snapshot: 'mdi.camera',
+        Setpoint: 'mdi.target',
+        Readback: 'mdi.book-open-variant',
+    }
+
+    return page_map, icon_map
+
+
+PAGE_MAP, ICON_MAP = get_page_icon_map()

--- a/superscore/widgets/page/search.py
+++ b/superscore/widgets/page/search.py
@@ -97,16 +97,15 @@ class SearchPage(Display, QtWidgets.QWidget):
         search_kwargs = {}
 
         # type
-        entry_type_list = []
+        entry_type_list = [Snapshot, Collection, Setpoint, Readback]
         for checkbox, entry_type in zip(
             self.type_checkboxes,
             (Snapshot, Collection, Setpoint, Readback)
         ):
-            if checkbox.isChecked():
-                entry_type_list.append(entry_type)
+            if not checkbox.isChecked():
+                entry_type_list.remove(entry_type)
 
-        if entry_type_list:
-            search_kwargs["entry_type"] = tuple(entry_type_list)
+        search_kwargs["entry_type"] = tuple(entry_type_list)
 
         # name
         name = self.name_line_edit.text()
@@ -180,7 +179,7 @@ class ResultModel(QtCore.QAbstractTableModel):
         # Special handling for open button delegate
         if index.column() == (len(self.headers) - 1):
             if role in (QtCore.Qt.DisplayRole, QtCore.Qt.EditRole):
-                return 'open'
+                return 'click to open'
 
         if role != QtCore.Qt.DisplayRole:
             # table is read only

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -3,9 +3,19 @@ Top-level window widget that contains other widgets
 """
 from __future__ import annotations
 
-from qtpy import QtWidgets
+import logging
+from typing import Optional
 
+import qtawesome as qta
+from qtpy import QtCore, QtWidgets
+
+from superscore.client import Client
+from superscore.model import Entry
 from superscore.widgets.core import Display
+from superscore.widgets.page import ICON_MAP, PAGE_MAP
+from superscore.widgets.page.search import SearchPage
+
+logger = logging.getLogger(__name__)
 
 
 class Window(Display, QtWidgets.QMainWindow):
@@ -16,5 +26,53 @@ class Window(Display, QtWidgets.QMainWindow):
     tree_view: QtWidgets.QTreeView
     tab_widget: QtWidgets.QTabWidget
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, client: Optional[Client] = None, **kwargs):
         super().__init__(*args, **kwargs)
+        if client:
+            self.client = client
+        else:
+            self.client = Client.from_config()
+
+        self.open_search_page()
+
+    def setup_ui(self) -> None:
+        tab_bar = self.tab_widget.tabBar()
+        # always use scroll area and never truncate file names
+        tab_bar.setUsesScrollButtons(True)
+        tab_bar.setElideMode(QtCore.Qt.ElideNone)
+        self.tab_widget.tabCloseRequested.connect(self.tab_widget.removeTab)
+
+    def open_page(self, entry: Entry) -> None:
+        """
+        Open a page for ``entry`` in a new tab.
+
+        Parameters
+        ----------
+        entry : Entry
+            Entry subclass to open a new page for
+        """
+        logger.debug(f'attempting to open {entry}')
+        if not isinstance(entry, Entry):
+            logger.debug('Could not open page for non-Entry dataclass')
+            return
+
+        if type(entry) not in PAGE_MAP:
+            logger.debug(f'No page corresponding to {type(entry).__name__}')
+
+        try:
+            page = PAGE_MAP[type(entry)]
+        except KeyError:
+            logger.debug(f'No page widget for {type(entry)}, cannot open in tab')
+            return
+
+        page_widget = page(data=entry)
+        icon = qta.icon(ICON_MAP[type(entry)])
+        tab_name = getattr(
+            entry, 'title', getattr(entry, 'pv_name', f'<{type(entry).__name__}>')
+        )
+        idx = self.tab_widget.addTab(page_widget, icon, tab_name)
+        self.tab_widget.setCurrentIndex(idx)
+
+    def open_search_page(self) -> None:
+        page = SearchPage(client=self.client, open_page_slot=self.open_page)
+        self.tab_widget.addTab(page, 'search')

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -33,6 +33,7 @@ class Window(Display, QtWidgets.QMainWindow):
         else:
             self.client = Client.from_config()
 
+        self.setup_ui()
         self.open_search_page()
 
     def setup_ui(self) -> None:


### PR DESCRIPTION
## Description
- Adds an open-page slot that can be passed to other pages
  - Passes this to the search page for opening search results
- Adds some icons for fun, adds them to tabs
- Sets up `superscore ui` to open the search page automatically, which now requires a `SUPERSCORE_CFG` to be discoverable

## Motivation and Context
closes #62 

## How Has This Been Tested?
Interactively

## Where Has This Been Documented?
This PR

![image](https://github.com/user-attachments/assets/68769cb2-a244-4851-9719-037e4ea88bff)

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
