### PR TITLE
MNT: Common table views, Primarily LivePVTableModel, minor skeleton work on NestableTableModel

### DIFF
--- a/docs/source/upcoming_release_notes/72-mnt_common_views.rst
+++ b/docs/source/upcoming_release_notes/72-mnt_common_views.rst
@@ -1,0 +1,24 @@
+72 mnt_common_views
+###################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Adds ``BaseTableEntryModel``, from which ``LivePVTableModel`` and ``NestableTableModel`` inherit.
+  These table models are intended to display ``Entry`` data and be reused across the application.
+- Implements ``LivePVTableModel``, including polling behavior for live PV display.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/superscore/control_layers/core.py
+++ b/superscore/control_layers/core.py
@@ -83,12 +83,12 @@ class ControlLayer:
 
         Parameters
         ----------
-        address : Union[str, list[str]]
+        address : Union[str, Iterable[str]]
             The PV(s) to get values for.
 
         Returns
         -------
-        Union[EpicsData, list[EpicsData]]
+        Union[EpicsData, Iterable[EpicsData]]
             The requested data
         """
         # Dispatches to _get_single and _get_list depending on type

--- a/superscore/tests/test_views.py
+++ b/superscore/tests/test_views.py
@@ -1,0 +1,55 @@
+from unittest.mock import MagicMock
+
+import pytest
+from pytestqt.qtbot import QtBot
+from qtpy import QtCore
+
+from superscore.client import Client
+from superscore.model import Parameter
+from superscore.widgets.views import LivePVTableModel
+
+
+@pytest.fixture(scope='function')
+def pv_poll_model(
+    mock_client: Client,
+    parameter_with_readback: Parameter,
+    qtbot: QtBot
+) -> LivePVTableModel:
+    model = LivePVTableModel(
+        client=mock_client,
+        entries=[parameter_with_readback],
+        poll_rate=1.0
+    )
+
+    # Make sure we never actually call EPICS
+    model.client.cl.get = MagicMock(return_value=1)
+    yield model
+
+    model.stop_polling()
+
+    qtbot.wait_until(lambda: not model._polling)
+
+
+def test_pvmodel_polling(pv_poll_model: LivePVTableModel, qtbot: QtBot):
+    thread = pv_poll_model._poll_thread
+    qtbot.wait_until(lambda: thread.running)
+
+    pv_poll_model.stop_polling()
+    qtbot.wait_until(lambda: thread.isFinished(), timeout=10000)
+    assert not thread.running
+
+
+def test_pvmodel_update(pv_poll_model: LivePVTableModel, qtbot: QtBot):
+    qtbot.wait_until(lambda: pv_poll_model._poll_thread.running)
+
+    assert pv_poll_model._data_cache
+
+    # make the mock cl return a new value
+    pv_poll_model.client.cl.get = MagicMock(return_value=3)
+
+    qtbot.wait_signal(pv_poll_model.dataChanged)
+
+    data_index = pv_poll_model.index_from_item(pv_poll_model.entries[0], 'Live Value')
+    qtbot.wait_until(
+        lambda: pv_poll_model.data(data_index, QtCore.Qt.DisplayRole) == '3'
+    )

--- a/superscore/tests/test_widgets.py
+++ b/superscore/tests/test_widgets.py
@@ -7,7 +7,7 @@ from pytestqt.qtbot import QtBot
 
 from superscore.model import Collection, Root
 from superscore.widgets.core import DataWidget
-from superscore.widgets.tree import RootTree
+from superscore.widgets.views import RootTree
 
 
 @pytest.mark.parametrize(

--- a/superscore/widgets/page/entry.py
+++ b/superscore/widgets/page/entry.py
@@ -7,7 +7,7 @@ from qtpy import QtWidgets
 from superscore.model import Collection
 from superscore.widgets.core import DataWidget, Display, NameDescTagsWidget
 from superscore.widgets.manip_helpers import insert_widget
-from superscore.widgets.tree import RootTree
+from superscore.widgets.views import RootTree
 
 
 class CollectionPage(Display, DataWidget):

--- a/superscore/widgets/page/search.py
+++ b/superscore/widgets/page/search.py
@@ -11,6 +11,7 @@ from superscore.client import Client
 from superscore.model import Collection, Entry, Readback, Setpoint, Snapshot
 from superscore.widgets import ICON_MAP
 from superscore.widgets.core import Display
+from superscore.widgets.views import BaseTableEntryModel, ButtonDelegate
 
 logger = logging.getLogger(__name__)
 
@@ -150,7 +151,7 @@ class SearchPage(Display, QtWidgets.QWidget):
         self.proxy_model.invalidateFilter()
 
 
-class ResultModel(QtCore.QAbstractTableModel):
+class ResultModel(BaseTableEntryModel):
     headers: List[str] = ['Name', 'Type', 'Description', 'Created', 'Open']
 
     def __init__(self, *args, entries: List[Entry] = None, **kwargs) -> None:
@@ -197,76 +198,6 @@ class ResultModel(QtCore.QAbstractTableModel):
 
         # if nothing is found, return invalid QVariant
         return QtCore.QVariant()
-
-    def rowCount(self, index):
-        return len(self.entries)
-
-    def columnCount(self, index):
-        return len(self.headers)
-
-    def headerData(
-        self,
-        section: int,
-        orientation: QtCore.Qt.Orientation,
-        role: int
-    ) -> Any:
-        """
-        Returns the header data for the model.
-        Currently only displays horizontal header data
-        """
-        if role != QtCore.Qt.DisplayRole:
-            return
-
-        if orientation == QtCore.Qt.Horizontal:
-            return self.headers[section]
-
-    def flags(self, index: QtCore.QModelIndex) -> QtCore.Qt.ItemFlag:
-        """
-        Returns the item flags for the given ``index``.  The returned
-        item flag controls what behaviors the item supports.
-
-        Parameters
-        ----------
-        index : QtCore.QModelIndex
-            the index referring to a cell of the TableView
-
-        Returns
-        -------
-        QtCore.Qt.ItemFlag
-            the ItemFlag corresponding to the cell
-        """
-        if (index.column() == len(self.headers) - 1):
-            return QtCore.Qt.ItemIsEditable | QtCore.Qt.ItemIsEnabled
-        else:
-            return QtCore.Qt.ItemIsEnabled
-
-
-class ButtonDelegate(QtWidgets.QStyledItemDelegate):
-    clicked = QtCore.Signal(QtCore.QModelIndex)
-
-    def __init__(self, *args, button_text: str = '', **kwargs):
-        self.button_text = button_text
-        super().__init__(*args, **kwargs)
-
-    def createEditor(
-        self,
-        parent: QtWidgets.QWidget,
-        option,
-        index: QtCore.QModelIndex
-    ) -> QtWidgets.QWidget:
-        button = QtWidgets.QPushButton(self.button_text, parent)
-        button.clicked.connect(
-            lambda _, index=index: self.clicked.emit(index)
-        )
-        return button
-
-    def updateEditorGeometry(
-        self,
-        editor: QtWidgets.QWidget,
-        option: QtWidgets.QStyleOptionViewItem,
-        index: QtCore.QModelIndex
-    ) -> None:
-        return editor.setGeometry(option.rect)
 
 
 class ResultFilterProxyModel(QtCore.QSortFilterProxyModel):

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -643,6 +643,23 @@ class LivePVTableModel(BaseTableEntryModel):
         item: PVEntry,
         column: Union[str, int]
     ) -> QtCore.QModelIndex:
+        """
+        Create an index given a `PVEntry` and desired column.
+        The column name must be an option in `LivePVHeaderEnum`, or able to be
+        converted to one by swapping ' ' with '_'
+
+        Parameters
+        ----------
+        item : PVEntry
+            A PVEntry dataclass instance
+        column : Union[str, int]
+            A column name or column index
+
+        Returns
+        -------
+        QtCore.QModelIndex
+            The corresponding model index
+        """
         row = self.entries.index(item)
         if isinstance(column, int):
             col = column
@@ -753,11 +770,15 @@ class LivePVTableModel(BaseTableEntryModel):
 
     def get_cache_data(self, pv_name: str) -> EpicsData:
         """
-        Get data from cache if possible.  If unavailable, dispatch to background
-        thread to fill.  String-ifies data for display
+        Get data from cache if possible.  If missing from cache, add pv_name for
+        the polling thread to update.
         """
         data = self._data_cache.get(pv_name, None)
+
         if data is None:
+            if pv_name not in self._data_cache:
+                self._data_cache[pv_name] = None
+
             # TODO: A neat spinny icon maybe?
             return "fetching..."
         else:

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -15,7 +15,7 @@ from superscore.widgets import ICON_MAP
 from superscore.widgets.core import Display
 from superscore.widgets.page import PAGE_MAP
 from superscore.widgets.page.search import SearchPage
-from superscore.widgets.tree import RootTree
+from superscore.widgets.views import RootTree
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description
Build a couple table models that can hopefully be reused elsewhere.  Includes:
- `LivePVTableModel`: a model for displaying {Parameter, Readback, Setpoint} data alongside the current values
- `NestableTableModel`: a model for {Collection, Snapshot} entries, which shows title / description primarily
- `BaseTableModel` that holds their own entries

Also:
- refactors a bit of the existing table models
- Adds a `_PVPollThread` for grabbing data outside the GUI thread

Note: I renamed `superscore.widgets.tree` -> `superscore.widgets.views`, but the diff viewer doesn't pick that up.  I did not change the tree model at all, so the reviews can focus on the table models

To-do (in a later PR at this point):
- [ ] make columns hide-able (see #76)
- [x] Refine columns (also showing live status and severity?  This might wait on #71)
- [ ] Hierarchical headers to condense views (see #76)
- [x] Finesse poll callbacks and signals to minimally update the table

## Motivation and Context
Building screens, I fell down this rabbit hole and the diff warranted a separate PR

## How Has This Been Tested?
Interactively so far, a couple tests added

## Where Has This Been Documented?
This PR

![image](https://github.com/user-attachments/assets/20305d3e-00ad-4f8d-811e-224d27e60909)

![image](https://github.com/user-attachments/assets/979457af-abdb-475c-acce-243c496b1797)


## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
