### PR TITLE
ENH: Unify data handling under `EpicsData`

### DIFF
--- a/docs/source/upcoming_release_notes/73-enh_unify_data.rst
+++ b/docs/source/upcoming_release_notes/73-enh_unify_data.rst
@@ -1,0 +1,22 @@
+73 enh_unify_data
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Standardize data handling to create and expect EpicsData instead of backend-specific data types.
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Adjust Status, Severity enums to start at 0, matching EPICS
+
+Contributors
+------------
+- tangkong

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -8,12 +8,11 @@ from uuid import UUID
 
 from superscore.backends import get_backend
 from superscore.backends.core import _Backend
-from superscore.control_layers import ControlLayer
+from superscore.control_layers import ControlLayer, EpicsData
 from superscore.control_layers.status import TaskStatus
 from superscore.errors import CommunicationError
 from superscore.model import (Collection, Entry, Nestable, Parameter, Readback,
                               Setpoint, Snapshot)
-from superscore.type_hints import AnyEpicsType
 from superscore.utils import build_abs_path
 
 logger = logging.getLogger(__name__)
@@ -290,7 +289,7 @@ class Client:
     def _build_snapshot(
         self,
         coll: Collection,
-        values: Dict[str, AnyEpicsType],
+        values: Dict[str, EpicsData],
     ) -> Snapshot:
         """
         Traverse a Collection, assembling a Snapshot using pre-fetched data
@@ -300,7 +299,7 @@ class Client:
         ----------
         coll : Collection
             The collection being saved
-        values : Dict[str, AnyEpicsType]
+        values : Dict[str, EpicsData]
             A dictionary mapping PV names to pre-fetched values
 
         Returns
@@ -319,17 +318,23 @@ class Client:
                 child = self.backend.get(child)
             if isinstance(child, Parameter):
                 if child.readback is not None:
+                    edata = values[child.readback.pv_name] or EpicsData(data=None)
                     readback = Readback(
                         pv_name=child.readback.pv_name,
                         description=child.readback.description,
-                        data=values[child.readback.pv_name]
+                        data=edata.data,
+                        status=edata.status,
+                        severity=edata.severity
                     )
                 else:
                     readback = None
+                edata = values[child.pv_name] or EpicsData(data=None)
                 setpoint = Setpoint(
                     pv_name=child.pv_name,
                     description=child.description,
-                    data=values[child.pv_name],
+                    data=edata.data,
+                    status=edata.status,
+                    severity=edata.severity,
                     readback=readback
                 )
                 snapshot.children.append(setpoint)
@@ -338,9 +343,12 @@ class Client:
 
         snapshot.meta_pvs = []
         for pv in Collection.meta_pvs:
+            edata = values[pv] or EpicsData(data=None)
             readback = Readback(
-                pv_name=readback.pv_name,
-                data=values[readback.pv_name]
+                pv_name=pv,
+                data=edata.data,
+                status=edata.status,
+                severity=edata.severity,
             )
             snapshot.meta_pvs.append(readback)
 

--- a/superscore/control_layers/__init__.py
+++ b/superscore/control_layers/__init__.py
@@ -1,2 +1,3 @@
+from ._base_shim import EpicsData  # noqa
 from .core import ControlLayer  # noqa
 from .status import TaskStatus  # noqa

--- a/superscore/control_layers/_aioca.py
+++ b/superscore/control_layers/_aioca.py
@@ -28,7 +28,7 @@ class AiocaShim(_BaseShim):
 
         Returns
         -------
-        Any
+        EpicsData
             The data at ``address``.
 
         Raises
@@ -79,7 +79,8 @@ class AiocaShim(_BaseShim):
         """
         camonitor(address, callback)
 
-    def value_to_epics_data(cls, value: AugmentedValue) -> EpicsData:
+    @staticmethod
+    def value_to_epics_data(value: AugmentedValue) -> EpicsData:
         """
         Creates an EpicsData instance from an aioca provided AugmentedValue
         Assumes the augmented value was collected with FORMAT_TIME qualifier.

--- a/superscore/control_layers/_base_shim.py
+++ b/superscore/control_layers/_base_shim.py
@@ -1,9 +1,17 @@
 """
 Base shim abstract base class
 """
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any, Callable
 
+from aioca.types import AugmentedValue
+
+from superscore.model import Severity, Status
 from superscore.type_hints import AnyEpicsType
+from superscore.utils import utcnow
 
 
 class _BaseShim:
@@ -15,3 +23,41 @@ class _BaseShim:
 
     def monitor(self, address: str, callback: Callable):
         raise NotImplementedError
+
+
+@dataclass
+class EpicsData:
+    """Unified EPICS data type for holding data and relevant metadata"""
+    data: AnyEpicsType
+    status: Severity = Status.UDF
+    severity: Status = Severity.INVALID
+    timestamp: datetime = field(default_factory=utcnow)
+
+    @classmethod
+    def from_aioca(cls, value: AugmentedValue) -> EpicsData:
+        """
+        Creates an EpicsData instance from an aioca provided AugmentedValue
+        Assumes the augmented value was collected with FORMAT_TIME qualifier.
+        AugmentedValue subclasses primitive datatypes, so they can be used as
+        data directly.
+
+        Parameters
+        ----------
+        value : AugmentedValue
+            The value to repackage
+
+        Returns
+        -------
+        EpicsData
+            The filled EpicsData instance
+        """
+        severity = Severity(value.severity)
+        status = Status(value.status)
+        timestamp = value.timestamp
+
+        return EpicsData(
+            data=value,
+            status=status,
+            severity=severity,
+            timestamp=timestamp
+        )

--- a/superscore/control_layers/_base_shim.py
+++ b/superscore/control_layers/_base_shim.py
@@ -7,8 +7,6 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Callable
 
-from aioca.types import AugmentedValue
-
 from superscore.model import Severity, Status
 from superscore.type_hints import AnyEpicsType
 from superscore.utils import utcnow
@@ -32,32 +30,3 @@ class EpicsData:
     status: Severity = Status.UDF
     severity: Status = Severity.INVALID
     timestamp: datetime = field(default_factory=utcnow)
-
-    @classmethod
-    def from_aioca(cls, value: AugmentedValue) -> EpicsData:
-        """
-        Creates an EpicsData instance from an aioca provided AugmentedValue
-        Assumes the augmented value was collected with FORMAT_TIME qualifier.
-        AugmentedValue subclasses primitive datatypes, so they can be used as
-        data directly.
-
-        Parameters
-        ----------
-        value : AugmentedValue
-            The value to repackage
-
-        Returns
-        -------
-        EpicsData
-            The filled EpicsData instance
-        """
-        severity = Severity(value.severity)
-        status = Status(value.status)
-        timestamp = value.timestamp
-
-        return EpicsData(
-            data=value,
-            status=status,
-            severity=severity,
-            timestamp=timestamp
-        )

--- a/superscore/control_layers/_base_shim.py
+++ b/superscore/control_layers/_base_shim.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 from superscore.model import Severity, Status
 from superscore.type_hints import AnyEpicsType
@@ -26,7 +26,7 @@ class _BaseShim:
 @dataclass
 class EpicsData:
     """Unified EPICS data type for holding data and relevant metadata"""
-    data: AnyEpicsType
+    data: Optional[AnyEpicsType]
     status: Severity = Status.UDF
     severity: Status = Severity.INVALID
     timestamp: datetime = field(default_factory=utcnow)

--- a/superscore/control_layers/_base_shim.py
+++ b/superscore/control_layers/_base_shim.py
@@ -13,7 +13,7 @@ from superscore.utils import utcnow
 
 
 class _BaseShim:
-    async def get(self, address: str) -> AnyEpicsType:
+    async def get(self, address: str) -> EpicsData:
         raise NotImplementedError
 
     async def put(self, address: str, value: Any):

--- a/superscore/control_layers/core.py
+++ b/superscore/control_layers/core.py
@@ -75,7 +75,7 @@ class ControlLayer:
         return shim
 
     @singledispatchmethod
-    def get(self, address: Union[str, list[str]]) -> Union[EpicsData, list[EpicsData]]:
+    def get(self, address: Union[str, Iterable[str]]) -> Union[EpicsData, Iterable[EpicsData]]:
         """
         Get the value(s) in ``address``.
         If a single pv is provided, will return a single value.

--- a/superscore/control_layers/core.py
+++ b/superscore/control_layers/core.py
@@ -8,6 +8,7 @@ from collections.abc import Iterable
 from functools import singledispatchmethod
 from typing import Any, Callable, Dict, List, Optional, Union
 
+from superscore.control_layers._base_shim import EpicsData
 from superscore.control_layers.status import TaskStatus
 
 from ._aioca import AiocaShim
@@ -74,7 +75,7 @@ class ControlLayer:
         return shim
 
     @singledispatchmethod
-    def get(self, address: Union[str, list[str]]) -> Any:
+    def get(self, address: Union[str, list[str]]) -> Union[EpicsData, list[EpicsData]]:
         """
         Get the value(s) in ``address``.
         If a single pv is provided, will return a single value.
@@ -87,7 +88,7 @@ class ControlLayer:
 
         Returns
         -------
-        Any
+        Union[EpicsData, list[EpicsData]]
             The requested data
         """
         # Dispatches to _get_single and _get_list depending on type
@@ -95,12 +96,12 @@ class ControlLayer:
               "a string or list of strings")
 
     @get.register
-    def _get_single(self, address: str) -> Any:
+    def _get_single(self, address: str) -> EpicsData:
         """Synchronously get a single ``address``"""
         return asyncio.run(self._get_one(address))
 
     @get.register
-    def _get_list(self, address: Iterable) -> Any:
+    def _get_list(self, address: Iterable) -> Iterable[EpicsData]:
         """Synchronously get a list of ``address``"""
         async def gathered_coros():
             coros = []

--- a/superscore/model.py
+++ b/superscore/model.py
@@ -20,14 +20,14 @@ _root_uuid = _root_uuid = UUID("a28cd77d-cc92-46cc-90cb-758f0f36f041")
 
 
 class Severity(IntEnum):
-    NO_ALARM = auto()
+    NO_ALARM = 0
     MINOR = auto()
     MAJOR = auto()
     INVALID = auto()
 
 
 class Status(IntEnum):
-    NO_ALARM = auto()
+    NO_ALARM = 0
     READ = auto()
     WRITE = auto()
     HIHI = auto()

--- a/superscore/tests/db/filestore.json
+++ b/superscore/tests/db/filestore.json
@@ -20,8 +20,8 @@
         "creation_time": "2024-05-10T16:49:34.574875+00:00",
         "pv_name": "MY:MOTOR:mtr1.ACCL",
         "data": 2,
-        "status": 18,
-        "severity": 4,
+        "status": 17,
+        "severity": 3,
         "readback": null
       }
     },
@@ -80,8 +80,11 @@
             "creation_time": "2024-05-10T16:49:34.574951+00:00",
             "pv_name": "MY:PREFIX:mtr1.ACCL",
             "data": 2,
-            "status": 18,
-            "severity": 4
+            "status": 17,
+            "severity": 3,
+            "abs_tolerance": null,
+            "rel_tolerance": null,
+            "timeout": null
           },
           {
             "uuid": "8e380e15-5489-41db-a8a7-bc47a731f099",
@@ -89,8 +92,11 @@
             "creation_time": "2024-05-10T16:49:34.574987+00:00",
             "pv_name": "MY:PREFIX:mtr1.VELO",
             "data": 2,
-            "status": 18,
-            "severity": 4
+            "status": 17,
+            "severity": 3,
+            "abs_tolerance": null,
+            "rel_tolerance": null,
+            "timeout": null
           },
           {
             "uuid": "ed8318d7-8c72-4d47-82d0-d75216d11565",
@@ -98,8 +104,11 @@
             "creation_time": "2024-05-10T16:49:34.575022+00:00",
             "pv_name": "MY:PREFIX:mtr1.PREC",
             "data": 6,
-            "status": 18,
-            "severity": 4
+            "status": 17,
+            "severity": 3,
+            "abs_tolerance": null,
+            "rel_tolerance": null,
+            "timeout": null
           }
         ],
         "tags": [],

--- a/superscore/tests/test_client.py
+++ b/superscore/tests/test_client.py
@@ -6,6 +6,7 @@ import pytest
 
 from superscore.backends.filestore import FilestoreBackend
 from superscore.client import Client
+from superscore.control_layers import EpicsData
 from superscore.errors import CommunicationError
 from superscore.model import Parameter, Readback, Root, Setpoint
 
@@ -84,7 +85,7 @@ def test_snap(
     coll = sample_database.entries[2]
     coll.children.append(parameter_with_readback)
 
-    get_mock.side_effect = range(5)
+    get_mock.side_effect = [EpicsData(i) for i in range(5)]
     snapshot = mock_client.snap(coll)
     assert get_mock.call_count == 5
     assert all([snapshot.children[i].data == i for i in range(4)])  # children saved in order
@@ -97,7 +98,8 @@ def test_snap(
 @patch('superscore.control_layers.core.ControlLayer._get_one')
 def test_snap_exception(get_mock, mock_client: Client, sample_database: Root):
     coll = sample_database.entries[2]
-    get_mock.side_effect = [0, 1, CommunicationError, 3, 4]
+    get_mock.side_effect = [EpicsData(0), EpicsData(1), CommunicationError,
+                            EpicsData(3), EpicsData(4)]
     snapshot = mock_client.snap(coll)
     assert snapshot.children[2].data is None
 


### PR DESCRIPTION
## Description
Standardize our data handling to create and expect EpicsData instead of backend-specific data types.
Adjust tests and Client methods to comply with this change

## Motivation and Context
We weren't handling status and severity before, and we should do so in a unified way
closes #71 

Various libraries handle this EPICS metadata differently.  
* `aioca` defines an `AugmentedValue` protocol, which in python just means it's promising the returned value will have the same fields as `AugmentedValue`.  In reality the returned values are `epicscorelibs.ca.dbr.<ca_datatype>` types, which subclass python primitives and ONLY have fields dictated by the `format` kwarg
  * This means that even though the return value supposedly implements the `AugmentedValue` interface, it's not guaranteed to.  (tsk tsk)
* `pyepics` gets this information from the `cainfo` function, which calls `PV.get_ctrlvars` under the hood.  The metadata is then stored on the `PV` object (I believe)
* `p4p` seems to create a subclass of their own `NTBase` for each epics NT, and status/severity are stored as attributes on that object
  * These NT classes also subclass python primitives
  * confusingly, they define a `Type` class of their own to use throughout all this

In the end I think this is the minimal amount of work to get us to the place we want.  After we grab data from EPICS, we're dealing with normal data types stored in the `superscore.model` dataclasses, and won't be handling this custom shim layer anyway.  

## How Has This Been Tested?
Tests made to pass

## Where Has This Been Documented?
This PR, and issue conversations

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
