### PR TITLE
MNT: read-only Parameters should be snapshotted as Readback, and propagate tolerances

### DIFF
--- a/docs/source/upcoming_release_notes/77-mnt_snap_ro_readback.rst
+++ b/docs/source/upcoming_release_notes/77-mnt_snap_ro_readback.rst
@@ -1,0 +1,23 @@
+77 mnt_snap_ro_readback
+#######################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Adjusts Client.snap so that if a `Parameter` in a `Collection` is marked as
+  read_only=True, it should be captured as a `Readback` in the corresponding `Snapshot`.
+
+Contributors
+------------
+- tangkong

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -326,20 +326,34 @@ class Client:
                         description=child.readback.description,
                         data=edata.data,
                         status=edata.status,
-                        severity=edata.severity
+                        severity=edata.severity,
+                        rel_tolerance=child.readback.rel_tolerance,
+                        abs_tolerance=child.readback.abs_tolerance,
                     )
                 else:
                     readback = None
                 edata = self._value_or_default(values.get(child.pv_name, None))
-                setpoint = Setpoint(
-                    pv_name=child.pv_name,
-                    description=child.description,
-                    data=edata.data,
-                    status=edata.status,
-                    severity=edata.severity,
-                    readback=readback
-                )
-                snapshot.children.append(setpoint)
+                if child.read_only:
+                    # create a readback and propagate tolerances
+                    new_entry = Readback(
+                        pv_name=child.pv_name,
+                        description=child.description,
+                        data=edata.data,
+                        status=edata.status,
+                        severity=edata.severity,
+                        rel_tolerance=child.rel_tolerance,
+                        abs_tolerance=child.abs_tolerance,
+                    )
+                else:
+                    new_entry = Setpoint(
+                        pv_name=child.pv_name,
+                        description=child.description,
+                        data=edata.data,
+                        status=edata.status,
+                        severity=edata.severity,
+                        readback=readback
+                    )
+                snapshot.children.append(new_entry)
             elif isinstance(child, Collection):
                 snapshot.children.append(self._build_snapshot(child, values))
 


### PR DESCRIPTION
## Description
If a `Parameter` in a `Collection` is marked as `read_only=True`, it should be captured as a `Readback` in the corresponding `Snapshot`.

Previously it would always be captured as a `Setpoint`, which is implicitly read-write, and did not have tolerance information

## Motivation and Context
Stumbled across this in another effort

## How Has This Been Tested?
I have not yet added a test

## Where Has This Been Documented?
This PR

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
