### PR TITLE
MNT: return error rather than raising in ControlLayer._get_single

### DIFF
--- a/docs/source/upcoming_release_notes/78-cl_get_return_com_error.rst
+++ b/docs/source/upcoming_release_notes/78-cl_get_return_com_error.rst
@@ -1,0 +1,22 @@
+78 cl get return com error
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- ControlLayer._get_single: return CommunicationError rather than propagating
+
+Contributors
+------------
+- shilorigins

--- a/superscore/control_layers/core.py
+++ b/superscore/control_layers/core.py
@@ -10,6 +10,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 
 from superscore.control_layers._base_shim import EpicsData
 from superscore.control_layers.status import TaskStatus
+from superscore.errors import CommunicationError
 
 from ._aioca import AiocaShim
 from ._base_shim import _BaseShim
@@ -96,12 +97,15 @@ class ControlLayer:
               "a string or list of strings")
 
     @get.register
-    def _get_single(self, address: str) -> EpicsData:
+    def _get_single(self, address: str) -> Union[EpicsData, CommunicationError]:
         """Synchronously get a single ``address``"""
-        return asyncio.run(self._get_one(address))
+        try:
+            return asyncio.run(self._get_one(address))
+        except CommunicationError as e:
+            return e
 
     @get.register
-    def _get_list(self, address: Iterable) -> Iterable[EpicsData]:
+    def _get_list(self, address: Iterable) -> Iterable[Union[EpicsData, CommunicationError]]:
         """Synchronously get a list of ``address``"""
         async def gathered_coros():
             coros = []

--- a/superscore/tests/test_cl.py
+++ b/superscore/tests/test_cl.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from superscore.control_layers.status import TaskStatus
+from superscore.errors import CommunicationError
 
 
 def test_get(dummy_cl):
@@ -15,6 +16,12 @@ def test_get(dummy_cl):
     assert dummy_cl.get("pva://SOME_PREFIX") == "pva_value"
 
     assert dummy_cl.get(['a', 'b', 'c']) == ["ca_value" for i in range(3)]
+
+
+def test_get_communication_error(dummy_cl):
+    mock_get = AsyncMock(side_effect=CommunicationError("Example error"))
+    dummy_cl.shims['ca'].get = mock_get
+    assert isinstance(dummy_cl.get("SOME_PREFIX"), CommunicationError)
 
 
 def test_put(dummy_cl):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Adjust `_get_single` to intercept and return a `CommunicationError` rather than propagating it.

`_get_one` still raises the error so that alternative `get` methods will still propagate the error unless they make the decision to return it.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Context in #74 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New test: `test_cl.py::test_get_communication_error`
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
This PR
## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
