### PR TITLE
ENH: Augment search methods

### DIFF
--- a/docs/source/upcoming_release_notes/79-augment_search_methods.rst
+++ b/docs/source/upcoming_release_notes/79-augment_search_methods.rst
@@ -1,0 +1,24 @@
+79 augment search methods
+#################
+
+API Breaks
+----------
+- Client.search takes SearchTerms as *args rather than key-value pairs as **kwargs
+
+Features
+--------
+- regex search on Entry text fields
+- filter Entrys by tag
+- filter Entrys by attribute value
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- shilorigins

--- a/superscore/backends/core.py
+++ b/superscore/backends/core.py
@@ -1,13 +1,21 @@
 """
 Base superscore data storage backend interface
 """
-from collections import namedtuple
-from typing import Generator
+from collections.abc import Container, Generator
+from typing import NamedTuple, Union
 from uuid import UUID
 
 from superscore.model import Entry, Root
+from superscore.type_hints import AnyEpicsType
 
-SearchTerm = namedtuple('SearchTerm', ('attr', 'operator', 'value'))
+SearchTermValue = Union[AnyEpicsType, Container[AnyEpicsType], tuple[AnyEpicsType, ...]]
+SearchTermType = tuple[str, str, SearchTermValue]
+
+
+class SearchTerm(NamedTuple):
+    attr: str
+    operator: str
+    value: SearchTermValue
 
 
 class _Backend:
@@ -44,7 +52,7 @@ class _Backend:
         """
         raise NotImplementedError
 
-    def search(self, *search_terms) -> Generator[Entry, None, None]:
+    def search(self, *search_terms: SearchTermType) -> Generator[Entry, None, None]:
         """
         Yield Entry objects matching all ``search_terms``. Each SearchTerm has the format
         (<attr>, <operator>, <value>).  Some operators take tuples as values.

--- a/superscore/backends/core.py
+++ b/superscore/backends/core.py
@@ -1,16 +1,20 @@
 """
 Base superscore data storage backend interface
 """
+from collections import namedtuple
 from typing import Generator
 from uuid import UUID
 
 from superscore.model import Entry, Root
+
+SearchTerm = namedtuple('SearchTerm', ('attr', 'operator', 'value'))
 
 
 class _Backend:
     """
     Base class for data storage backend.
     """
+
     def get_entry(self, meta_id: UUID) -> Entry:
         """
         Get entry with ``meta_id``
@@ -40,8 +44,18 @@ class _Backend:
         """
         raise NotImplementedError
 
-    def search(self, **search_kwargs) -> Generator[Entry, None, None]:
-        """Yield a Entry objects corresponding matching ``search_kwargs``"""
+    def search(self, *search_terms) -> Generator[Entry, None, None]:
+        """
+        Yield Entry objects matching all ``search_terms``. Each SearchTerm has the format
+        (<attr>, <operator>, <value>).  Some operators take tuples as values.
+
+        The supported operators are:
+        - eq (equals)
+        - lt (less than or equal to)
+        - gt (greater than or equal to)
+        - in
+        - like (fuzzy match, depends on type of value)
+        """
         raise NotImplementedError
 
     @property

--- a/superscore/backends/filestore.py
+++ b/superscore/backends/filestore.py
@@ -337,9 +337,9 @@ class FilestoreBackend(_Backend):
         elif op == "in":
             return data in target
         elif op == "like":
-            if isinstance(data, str):
-                return re.search(target, data)
-        return NotImplemented
+            return re.search(target, data)
+        else:
+            raise ValueError(f"SearchTerm does not support operator \"{op}\"")
 
     @contextlib.contextmanager
     def _load_and_store_context(self) -> Generator[Dict[UUID, Any], None, None]:

--- a/superscore/backends/filestore.py
+++ b/superscore/backends/filestore.py
@@ -338,6 +338,8 @@ class FilestoreBackend(_Backend):
         elif op == "in":
             return data in target
         elif op == "like":
+            if isinstance(data, UUID):
+                data = str(data)
             return re.search(target, data)
         else:
             raise ValueError(f"SearchTerm does not support operator \"{op}\"")

--- a/superscore/backends/filestore.py
+++ b/superscore/backends/filestore.py
@@ -14,9 +14,10 @@ from uuid import UUID, uuid4
 
 from apischema import deserialize, serialize
 
-from superscore.backends.core import _Backend
+from superscore.backends.core import SearchTermType, SearchTermValue, _Backend
 from superscore.errors import BackendError
 from superscore.model import Entry, Root
+from superscore.type_hints import AnyEpicsType
 from superscore.utils import build_abs_path
 
 logger = logging.getLogger(__name__)
@@ -285,7 +286,7 @@ class FilestoreBackend(_Backend):
         with self._load_and_store_context() as db:
             db.pop(entry.uuid, None)
 
-    def search(self, *search_terms) -> Generator[Entry, None, None]:
+    def search(self, *search_terms: SearchTermType) -> Generator[Entry, None, None]:
         """
         Return entries that match all ``search_terms``.
         Keys are attributes on `Entry` subclasses, or special keywords.
@@ -309,7 +310,7 @@ class FilestoreBackend(_Backend):
                     yield entry
 
     @staticmethod
-    def compare(op: str, data, target) -> bool:
+    def compare(op: str, data: AnyEpicsType, target: SearchTermValue) -> bool:
         """
         Return whether data and target satisfy the op comparator, typically durihg application
         of a search filter. Possible values of op are detailed in _Backend.search

--- a/superscore/backends/filestore.py
+++ b/superscore/backends/filestore.py
@@ -339,10 +339,7 @@ class FilestoreBackend(_Backend):
         elif op == "like":
             if isinstance(data, str):
                 return re.search(target, data)
-            elif isinstance(data, (int, float)):
-                return data < 1.05 * target and data > .95 * target
-            else:
-                return NotImplemented
+        return NotImplemented
 
     @contextlib.contextmanager
     def _load_and_store_context(self) -> Generator[Dict[UUID, Any], None, None]:

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, Generator, List, Optional, Union
 from uuid import UUID
 
 from superscore.backends import get_backend
-from superscore.backends.core import SearchTerm, _Backend
+from superscore.backends.core import SearchTerm, SearchTermType, _Backend
 from superscore.control_layers import ControlLayer, EpicsData
 from superscore.control_layers.status import TaskStatus
 from superscore.errors import CommunicationError
@@ -147,7 +147,7 @@ class Client:
         # If found nothing
         raise OSError("No superscore configuration file found. Check SUPERSCORE_CFG.")
 
-    def search(self, *post) -> Generator[Entry, None, None]:
+    def search(self, *post: SearchTermType) -> Generator[Entry, None, None]:
         """
         Search backend for entries matching all SearchTerms in ``post``.  Can search by any
         field, plus some special keywords. Backends support operators listed in _Backend.search.

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -158,7 +158,7 @@ class Client:
         for search_term in post:
             if not isinstance(search_term, SearchTerm):
                 search_term = SearchTerm(*search_term)
-            if search_term.operator == 'like_with_tols':
+            if search_term.operator == 'isclose':
                 target, rel_tol, abs_tol = search_term.value
                 lower = target - target * rel_tol - abs_tol
                 upper = target + target * rel_tol + abs_tol

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -156,6 +156,8 @@ class Client:
         """
         new_search_terms = []
         for search_term in post:
+            if not isinstance(search_term, SearchTerm):
+                search_term = SearchTerm(*search_term)
             if search_term.operator == 'like_with_tols':
                 target, rel_tol, abs_tol = search_term.value
                 lower = target - target * rel_tol - abs_tol

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -147,9 +147,12 @@ class Client:
         # If found nothing
         raise OSError("No superscore configuration file found. Check SUPERSCORE_CFG.")
 
-    def search(self, **post) -> Generator[Entry, None, None]:
-        """Search by key-value pair.  Can search by any field, including id"""
-        return self.backend.search(**post)
+    def search(self, *post) -> Generator[Entry, None, None]:
+        """
+        Search backend for entries matching all SearchTerms in ``post``.  Can search by any
+        field, plus some special keywords. Backends support operators listed in _Backend.search.
+        """
+        return self.backend.search(*post)
 
     def save(self, entry: Entry):
         """Save information in ``entry`` to database"""

--- a/superscore/tests/test_backend.py
+++ b/superscore/tests/test_backend.py
@@ -127,6 +127,11 @@ def test_fuzzy_search(backends: _Backend):
     )
     assert len(results) == 2
 
+    results = list(backends.search(
+        SearchTerm('uuid', 'like', '17cc6ebf'))
+    )
+    assert len(results) == 1
+
 
 @pytest.mark.parametrize('backends', [0], indirect=True)
 def test_tag_search(backends: _Backend):

--- a/superscore/tests/test_backend.py
+++ b/superscore/tests/test_backend.py
@@ -2,7 +2,7 @@ from uuid import UUID
 
 import pytest
 
-from superscore.backends.core import _Backend
+from superscore.backends.core import SearchTerm, _Backend
 from superscore.errors import (BackendError, EntryExistsError,
                                EntryNotFoundError)
 from superscore.model import Collection, Parameter, Snapshot
@@ -73,42 +73,72 @@ def test_delete_entry(backends: _Backend):
 def test_search_entry(backends: _Backend):
     # Given an entry we know is in the backend
     results = backends.search(
-        description='collection 1 defining some motor fields'
+        SearchTerm('description', 'eq', 'collection 1 defining some motor fields')
     )
     assert len(list(results)) == 1
     # Search by field name
     results = backends.search(
-        uuid=UUID('ffd668d3-57d9-404e-8366-0778af7aee61')
+        SearchTerm('uuid', 'eq', UUID('ffd668d3-57d9-404e-8366-0778af7aee61'))
     )
     assert len(list(results)) == 1
     # Search by field name
-    results = backends.search(data=2)
+    results = backends.search(
+        SearchTerm('data', 'eq', 2)
+    )
     assert len(list(results)) == 3
     # Search by field name
     results = backends.search(
-        uuid=UUID('ecb42cdb-b703-4562-86e1-45bd67a2ab1a'), data=2
+        SearchTerm('uuid', 'eq', UUID('ecb42cdb-b703-4562-86e1-45bd67a2ab1a')),
+        SearchTerm('data', 'eq', 2)
     )
     assert len(list(results)) == 1
 
-    results = backends.search(entry_type=Snapshot,)
+    results = backends.search(
+        SearchTerm('entry_type', 'eq', Snapshot)
+    )
     assert len(list(results)) == 1
 
-    results = backends.search(entry_type=(Snapshot, Collection))
+    results = backends.search(
+        SearchTerm('entry_type', 'in', (Snapshot, Collection))
+    )
     assert len(list(results)) == 2
+
+    results = backends.search(
+        SearchTerm('data', 'lt', 3)
+    )
+    assert len(list(results)) == 3
+
+    results = backends.search(
+        SearchTerm('data', 'gt', 3)
+    )
+    assert len(list(results)) == 1
+
+
+@pytest.mark.parametrize('backends', [0], indirect=True)
+def test_fuzzy_search(backends: _Backend):
+    results = list(backends.search(
+        SearchTerm('description', 'like', 'motor'))
+    )
+    assert len(results) == 4
+
+    results = list(backends.search(
+        SearchTerm('description', 'like', 'motor field (?!PREC)'))
+    )
+    assert len(results) == 2
 
 
 @pytest.mark.parametrize('backends', [0], indirect=True)
 def test_update_entry(backends: _Backend):
     # grab an entry from the database and modify it.
     entry = list(backends.search(
-        description='collection 1 defining some motor fields'
+        SearchTerm('description', 'eq', 'collection 1 defining some motor fields')
     ))[0]
     old_uuid = entry.uuid
 
     entry.description = 'new_description'
     backends.update_entry(entry)
     new_entry = list(backends.search(
-        description='new_description'
+        SearchTerm('description', 'eq', 'new_description')
     ))[0]
     new_uuid = new_entry.uuid
 

--- a/superscore/tests/test_backend.py
+++ b/superscore/tests/test_backend.py
@@ -156,6 +156,20 @@ def test_tag_search(backends: _Backend):
 
 
 @pytest.mark.parametrize('backends', [0], indirect=True)
+def test_search_error(backends: _Backend):
+    with pytest.raises(TypeError):
+        results = backends.search(
+            SearchTerm('data', 'like', 5)
+        )
+        list(results)
+    with pytest.raises(ValueError):
+        results = backends.search(
+            SearchTerm('data', 'near', 5)
+        )
+        list(results)
+
+
+@pytest.mark.parametrize('backends', [0], indirect=True)
 def test_update_entry(backends: _Backend):
     # grab an entry from the database and modify it.
     entry = list(backends.search(

--- a/superscore/tests/test_client.py
+++ b/superscore/tests/test_client.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
+from superscore.backends.core import SearchTerm
 from superscore.backends.filestore import FilestoreBackend
 from superscore.client import Client
 from superscore.control_layers import EpicsData
@@ -136,3 +137,15 @@ def test_find_config(sscore_cfg: str):
     # explicit SUPERSCORE_CFG env var supercedes XDG_CONFIG_HOME
     os.environ['SUPERSCORE_CFG'] = 'other/cfg'
     assert 'other/cfg' == Client.find_config()
+
+
+def test_search(sample_client):
+    results = list(sample_client.search(
+        SearchTerm('data', 'like_with_tols', (4, 0, 0))
+    ))
+    assert len(results) == 0
+
+    results = list(sample_client.search(
+        SearchTerm('data', 'like_with_tols', (4, .5, 1))
+    ))
+    assert len(results) == 4

--- a/superscore/tests/test_client.py
+++ b/superscore/tests/test_client.py
@@ -141,11 +141,11 @@ def test_find_config(sscore_cfg: str):
 
 def test_search(sample_client):
     results = list(sample_client.search(
-        SearchTerm('data', 'like_with_tols', (4, 0, 0))
+        ('data', 'like_with_tols', (4, 0, 0))
     ))
     assert len(results) == 0
 
     results = list(sample_client.search(
-        SearchTerm('data', 'like_with_tols', (4, .5, 1))
+        SearchTerm(operator='like_with_tols', attr='data', value=(4, .5, 1))
     ))
     assert len(results) == 4

--- a/superscore/tests/test_client.py
+++ b/superscore/tests/test_client.py
@@ -141,11 +141,11 @@ def test_find_config(sscore_cfg: str):
 
 def test_search(sample_client):
     results = list(sample_client.search(
-        ('data', 'like_with_tols', (4, 0, 0))
+        ('data', 'isclose', (4, 0, 0))
     ))
     assert len(results) == 0
 
     results = list(sample_client.search(
-        SearchTerm(operator='like_with_tols', attr='data', value=(4, .5, 1))
+        SearchTerm(operator='isclose', attr='data', value=(4, .5, 1))
     ))
     assert len(results) == 4

--- a/superscore/widgets/page/collection_builder.py
+++ b/superscore/widgets/page/collection_builder.py
@@ -229,8 +229,8 @@ class CollectionBuilderPage(Display, DataWidget):
 
     def update_collection_choices(self):
         """update collection choices based on line edit"""
-        search_kwargs = {'entry_type': (Collection,)}
-        self._coll_options = [res for res in self.client.search(**search_kwargs)
+        search_term = ('entry_type', 'eq', Collection)
+        self._coll_options = [res for res in self.client.search(search_term)
                               if res not in (self.data.children, self)]
         logger.debug(f"Gathered {len(self._coll_options)} collections")
         self.coll_combo_box.clear()

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -16,6 +16,7 @@ import numpy as np
 import qtawesome as qta
 from qtpy import QtCore, QtGui, QtWidgets
 
+from superscore.backends.core import SearchTerm
 from superscore.client import Client
 from superscore.control_layers import EpicsData
 from superscore.model import (Collection, Entry, Nestable, Parameter, Readback,
@@ -66,7 +67,7 @@ class EntryItem:
     def fill_uuids(self, client: Optional[Client] = None) -> None:
         """Fill this item's data if it is a uuid, using ``client``"""
         if isinstance(self._data, UUID) and client is not None:
-            self._data = list(client.search(uuid=self._data))[0]
+            self._data = list(client.search(SearchTerm('uuid', 'eq', self._data)))[0]
 
     def data(self, column: int) -> Any:
         """


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
* Change search term format from keyword arg to namedtuple of `(<attribute>, <operator>, <value>)`
* Define `SearchTerm` namedtuple
* Modify search page, views, and tests to use new format

Closes #61 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
### SearchTerm Format
A three-term format provides more flexibility than a keyword arg. For example, we'd run into trouble using keyword args if we wanted to support both exact match and fuzzy match on entry titles, but with the tuple format we can apply different operators to the same attribute / value pairs.

Using a namedtuple for the format provides the option of setting and accessing args by name without taking more memory than bare tuples.  

### Operators
I included the operators:
* `eq` (equals)
* `lt` (less than or equal to)
* `gt` (greater than or equal to)
* `in` (item in container)
* `like` (partial match)
* `isclose` (number within absolute and relative tolerances)

`lt` and `gt` are both inclusive because I felt that that was more intuitive, and that we didn't need to also support exclusive versions. `like` currently supports regex string and UUID matches.

`isclose` takes an arg with format `(<value>, <rel_tolerance>, <abs_tolerance>)`.  The client converts this `SearchTerm` to `lt` and `gt`; the intention is that tolerances can be taken from the user or from the `Entry` directly, which the client turns into upper and lower bounds.

`entry_type` requires special handling because type comparisons need subclass information.

### Tags
`FilestoreBackend` implicitly supports tags using the `gt` operator, but a dedicated operator may be required when other backends are added. To find entries whose tag set contains all tags in a filter, use the conditional `('tags', 'gt', {<tags>...})`, which calls `set.__ge__`.  Supporting more complex tag filters, like inversion or disjunction, will also require a tag operator or using `Flag` functionality.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests in `test_page`, `test_window`, and `test_backend`.
New tests for `lt`, `gt`, fuzzy match, and tag filters.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
This PR
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
