### PR TITLE
BUG: close tabs in tab widget when main window is closed

### DIFF
--- a/docs/source/upcoming_release_notes/89-tab_widget_cleanup.rst
+++ b/docs/source/upcoming_release_notes/89-tab_widget_cleanup.rst
@@ -1,0 +1,22 @@
+89 tab widget cleanup
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Main window closes tab widget tabs when closed, so they can do their clean up
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- shilorigins

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -9,6 +9,7 @@ from typing import Optional
 import qtawesome as qta
 from pcdsutils.qt.callbacks import WeakPartialMethodSlot
 from qtpy import QtCore, QtWidgets
+from qtpy.QtGui import QCloseEvent
 
 from superscore.client import Client
 from superscore.model import Entry
@@ -137,3 +138,8 @@ class Window(Display, QtWidgets.QMainWindow):
             open_action.triggered.connect(open)
 
         self.menu.exec_(self.tree_view.mapToGlobal(pos))
+
+    def closeEvent(self, a0: QCloseEvent) -> None:
+        while self.tab_widget.count() > 0:
+            self.remove_tab(0)
+        super().closeEvent(a0)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Fix bug where `LivePVTableModel` polling threads aren't cleaned up when the main window is closed.

Closes #88 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #88 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
