### PR TITLE
ENH/REF: refactor shared table views

### DIFF
--- a/docs/source/upcoming_release_notes/90-enh_pv_nest_views.rst
+++ b/docs/source/upcoming_release_notes/90-enh_pv_nest_views.rst
@@ -1,0 +1,24 @@
+90 enh_pv_nest_views
+####################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Extends `EpicsData` fields to include controls metadata
+- Support editing for LivePVTableModel and NestableModel
+- Adds `ValueDelegate`, which provides an edit delegate based on the datatype of the cell
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Refactors common models to come with their own views, to improve user friendliness
+
+Contributors
+------------
+- tangkong

--- a/superscore/control_layers/_base_shim.py
+++ b/superscore/control_layers/_base_shim.py
@@ -30,3 +30,10 @@ class EpicsData:
     status: Severity = Status.UDF
     severity: Status = Severity.INVALID
     timestamp: datetime = field(default_factory=utcnow)
+
+    # Extra metadata
+    units: Optional[str] = None
+    precision: Optional[int] = None
+    upper_ctrl_limit: Optional[float] = None
+    lower_ctrl_limit: Optional[float] = None
+    enums: Optional[list[str]] = None

--- a/superscore/tests/conftest.py
+++ b/superscore/tests/conftest.py
@@ -772,7 +772,7 @@ def sample_client(
     filestore_backend: FilestoreBackend,
     dummy_cl: ControlLayer
 ) -> Client:
-    """Return a client with actula data, but no communication capabilities"""
+    """Return a client with actual data, but no communication capabilities"""
     client = Client(backend=filestore_backend)
     client.cl = dummy_cl
 

--- a/superscore/tests/conftest.py
+++ b/superscore/tests/conftest.py
@@ -707,6 +707,15 @@ def setpoint_with_readback() -> Setpoint:
     return setpoint
 
 
+@pytest.fixture(scope="function")
+def simple_snapshot() -> Collection:
+    snap = Snapshot(description='various types', title='types collection')
+    snap.children.append(Setpoint(pv_name="MY:FLOAT"))
+    snap.children.append(Setpoint(pv_name="MY:INT"))
+    snap.children.append(Setpoint(pv_name="MY:ENUM"))
+    return snap
+
+
 @pytest.fixture(scope='function')
 def filestore_backend(tmp_path: Path) -> FilestoreBackend:
     fp = Path(__file__).parent / 'db' / 'filestore.json'

--- a/superscore/tests/test_page.py
+++ b/superscore/tests/test_page.py
@@ -30,8 +30,8 @@ def collection_builder_page(qtbot: QtBot, sample_client: Client):
     page = CollectionBuilderPage(client=sample_client)
     qtbot.addWidget(page)
     yield page
-    page.pv_model.stop_polling()
-    qtbot.waitUntil(lambda: page.pv_model._poll_thread.isFinished())
+    page.close()
+    qtbot.waitUntil(lambda: page.sub_pv_table_view._model._poll_thread.isFinished())
 
 
 @pytest.mark.parametrize(
@@ -79,10 +79,10 @@ def test_coll_builder_add(collection_builder_page: CollectionBuilderPage):
     assert len(page.data.children) == 1
     assert "THIS:PV" in page.data.children[0].pv_name
     assert isinstance(page.data.children[0], Parameter)
-    assert page.pv_model.rowCount() == 1
+    assert page.sub_pv_table_view._model.rowCount() == 1
 
     page.coll_combo_box.setCurrentIndex(0)
     added_collection = page._coll_options[0]
     page.add_collection_button.clicked.emit()
     assert added_collection is page.data.children[1]
-    assert page.coll_model.rowCount() == 1
+    assert page.sub_coll_table_view._model.rowCount() == 1

--- a/superscore/tests/test_page.py
+++ b/superscore/tests/test_page.py
@@ -2,6 +2,7 @@
 
 import pytest
 from pytestqt.qtbot import QtBot
+from qtpy import QtCore
 
 from superscore.client import Client
 from superscore.model import Collection, Parameter
@@ -86,3 +87,30 @@ def test_coll_builder_add(collection_builder_page: CollectionBuilderPage):
     page.add_collection_button.clicked.emit()
     assert added_collection is page.data.children[1]
     assert page.sub_coll_table_view._model.rowCount() == 1
+
+
+def test_coll_builder_edit(
+    collection_builder_page: CollectionBuilderPage,
+    qtbot: QtBot
+):
+    page = collection_builder_page
+
+    page.pv_line_edit.setText("THIS:PV")
+    page.add_pvs_button.clicked.emit()
+
+    pv_model = page.sub_pv_table_view.model()
+    qtbot.waitUntil(lambda: pv_model.rowCount() == 1)
+    assert "THIS:PV" in page.data.children[0].pv_name
+
+    first_index = pv_model.createIndex(0, 0)
+    pv_model.setData(first_index, "NEW:VP", role=QtCore.Qt.EditRole)
+
+    assert "NEW:VP" in page.data.children[0].pv_name
+
+    page.add_collection_button.clicked.emit()
+
+    coll_model = page.sub_coll_table_view.model()
+    qtbot.waitUntil(lambda: coll_model.rowCount() == 1)
+
+    coll_model.setData(first_index, 'anothername', role=QtCore.Qt.EditRole)
+    qtbot.waitUntil(lambda: "anothername" in page.data.children[1].title)

--- a/superscore/tests/test_views.py
+++ b/superscore/tests/test_views.py
@@ -1,13 +1,17 @@
+import copy
+from typing import Any
 from unittest.mock import MagicMock
 
+import apischema
 import pytest
 from pytestqt.qtbot import QtBot
-from qtpy import QtCore
+from qtpy import QtCore, QtWidgets
 
 from superscore.client import Client
 from superscore.control_layers import EpicsData
-from superscore.model import Parameter
-from superscore.widgets.views import LivePVTableModel
+from superscore.model import Collection, Parameter, Severity, Status
+from superscore.widgets.views import (CustRoles, LivePVHeader,
+                                      LivePVTableModel, LivePVTableView)
 
 
 @pytest.fixture(scope='function')
@@ -15,7 +19,8 @@ def pv_poll_model(
     mock_client: Client,
     parameter_with_readback: Parameter,
     qtbot: QtBot
-) -> LivePVTableModel:
+):
+    """Minimal LivePVTableModel, containing only Parameters (no stored data)"""
     model = LivePVTableModel(
         client=mock_client,
         entries=[parameter_with_readback],
@@ -30,6 +35,42 @@ def pv_poll_model(
     model.stop_polling()
 
     qtbot.wait_until(lambda: not model._poll_thread.isRunning())
+
+
+@pytest.fixture(scope="function")
+def pv_table_view(
+    mock_client: Client,
+    simple_snapshot: Collection,
+    qtbot: QtBot,
+):
+    """
+    LivePVTableView, holds three PVs with different types.  Stored data allowed.
+    Mocks control layer to return realistic-ish EpicsData
+
+    TODO: add string field examples once we properly handle strings
+    """
+    # Build side effect function:
+    ret_vals = {
+        "MY:FLOAT": EpicsData(data=0.5, precision=3,
+                              upper_ctrl_limit=2, lower_ctrl_limit=-2),
+        "MY:INT": EpicsData(data=1, upper_ctrl_limit=10, lower_ctrl_limit=-10),
+        "MY:ENUM": EpicsData(data=0, enums=["OUT", "IN", "UNKNOWN"])
+    }
+
+    def simple_coll_return_vals(pv_name: str):
+        return ret_vals[pv_name]
+
+    mock_client.cl.get = MagicMock(side_effect=simple_coll_return_vals)
+
+    view = LivePVTableView()
+    view.client = mock_client
+    view.set_data(simple_snapshot)
+
+    qtbot.wait_until(lambda: view.model()._poll_thread.isRunning())
+    yield view
+
+    view.model().stop_polling()
+    qtbot.wait_until(lambda: not view.model()._poll_thread.isRunning())
 
 
 def test_pvmodel_polling(pv_poll_model: LivePVTableModel, qtbot: QtBot):
@@ -51,3 +92,98 @@ def test_pvmodel_update(pv_poll_model: LivePVTableModel, qtbot: QtBot):
     qtbot.wait_until(
         lambda: pv_poll_model.data(data_index, QtCore.Qt.DisplayRole) == '3'
     )
+
+
+@pytest.mark.parametrize("row,widget_cls,", [
+    (0, QtWidgets.QDoubleSpinBox),
+    (1, QtWidgets.QSpinBox),
+    (2, QtWidgets.QComboBox),
+])
+def test_pv_view_value_delegate_types(
+    row: int,
+    widget_cls: QtWidgets.QWidget,
+    pv_table_view: LivePVTableView,
+    qtbot: QtBot,
+):
+    model = pv_table_view.model()
+    assert isinstance(model, LivePVTableModel)
+
+    index = model.index(row, LivePVHeader.STORED_VALUE)
+
+    # let the data populate before checking delegate type
+    qtbot.wait_until(
+        lambda: isinstance(model.data(index, CustRoles.EpicsDataRole), EpicsData)
+    )
+
+    edit_widget = pv_table_view.value_delegate.createEditor(pv_table_view, 0, index)
+    assert isinstance(edit_widget, widget_cls)
+
+
+@pytest.mark.parametrize("col,widget_cls,", [
+    (LivePVHeader.PV_NAME, QtWidgets.QLineEdit),
+    (LivePVHeader.STORED_SEVERITY, QtWidgets.QComboBox),
+    (LivePVHeader.STORED_STATUS, QtWidgets.QComboBox),
+])
+def test_pv_view_common_delegate_types(
+    col: int,
+    widget_cls: QtWidgets.QWidget,
+    pv_table_view: LivePVTableView,
+    qtbot: QtBot,
+):
+    model = pv_table_view.model()
+    assert isinstance(model, LivePVTableModel)
+
+    index = model.index(0, col)
+
+    # unlike previous test, no waiting needed, since we don't initialize the
+    # widget with any live data
+
+    edit_widget = pv_table_view.value_delegate.createEditor(pv_table_view, 0, index)
+    assert isinstance(edit_widget, widget_cls)
+
+
+@pytest.mark.parametrize("row,input_data,", [
+    (0, 0.1),
+    (1, 2),
+    (2, 1),  # enum types get set as ints, viewed as strings
+])
+def test_set_data(
+    row: int,
+    input_data: Any,
+    pv_table_view: LivePVTableView
+):
+    orig_data = copy.deepcopy(pv_table_view.data)
+    orig_ser = apischema.serialize(type(pv_table_view.data), pv_table_view.data)
+
+    model = pv_table_view.model()
+    index = model.index(row, LivePVHeader.STORED_VALUE)
+
+    model.setData(index, input_data, QtCore.Qt.EditRole)
+
+    # round-trip ensures types translate properly
+    new_ser = apischema.serialize(type(pv_table_view.data), pv_table_view.data)
+    assert orig_data != pv_table_view.data
+    assert orig_ser != new_ser
+
+
+def test_stat_sev_enums(pv_table_view: LivePVTableView):
+    model = pv_table_view.model()
+    sev_index = model.index(0, LivePVHeader.STORED_SEVERITY)
+    sev_delegate = pv_table_view.value_delegate.createEditor(
+        pv_table_view, 0, sev_index
+    )
+
+    assert isinstance(sev_delegate, QtWidgets.QComboBox)
+    assert sev_delegate.count() == len(Severity)
+    for sev in Severity:
+        assert sev_delegate.itemText(sev.value).lower() == sev.name.lower()
+
+    stat_index = model.index(0, LivePVHeader.STORED_STATUS)
+    stat_delegate = pv_table_view.value_delegate.createEditor(
+        pv_table_view, 0, stat_index
+    )
+
+    assert isinstance(sev_delegate, QtWidgets.QComboBox)
+    assert stat_delegate.count() == len(Status)
+    for stat in Status:
+        assert stat_delegate.itemText(stat.value).lower() == stat.name.lower()

--- a/superscore/tests/test_views.py
+++ b/superscore/tests/test_views.py
@@ -128,7 +128,6 @@ def test_pv_view_common_delegate_types(
     col: int,
     widget_cls: QtWidgets.QWidget,
     pv_table_view: LivePVTableView,
-    qtbot: QtBot,
 ):
     model = pv_table_view.model()
     assert isinstance(model, LivePVTableModel)
@@ -162,6 +161,10 @@ def test_set_data(
 
     # round-trip ensures types translate properly
     new_ser = apischema.serialize(type(pv_table_view.data), pv_table_view.data)
+    new_data = apischema.deserialize(type(pv_table_view.data), new_ser)
+    assert pv_table_view.data == new_data
+
+    # data should not be the same as at beginning of test
     assert orig_data != pv_table_view.data
     assert orig_ser != new_ser
 

--- a/superscore/tests/test_views.py
+++ b/superscore/tests/test_views.py
@@ -5,6 +5,7 @@ from pytestqt.qtbot import QtBot
 from qtpy import QtCore
 
 from superscore.client import Client
+from superscore.control_layers import EpicsData
 from superscore.model import Parameter
 from superscore.widgets.views import LivePVTableModel
 
@@ -22,7 +23,7 @@ def pv_poll_model(
     )
 
     # Make sure we never actually call EPICS
-    model.client.cl.get = MagicMock(return_value=1)
+    model.client.cl.get = MagicMock(return_value=EpicsData(1))
     qtbot.wait_until(lambda: model._poll_thread.running)
     yield model
 
@@ -42,7 +43,7 @@ def test_pvmodel_update(pv_poll_model: LivePVTableModel, qtbot: QtBot):
     assert pv_poll_model._data_cache
 
     # make the mock cl return a new value
-    pv_poll_model.client.cl.get = MagicMock(return_value=3)
+    pv_poll_model.client.cl.get = MagicMock(return_value=EpicsData(3))
 
     qtbot.wait_signal(pv_poll_model.dataChanged)
 

--- a/superscore/tests/test_views.py
+++ b/superscore/tests/test_views.py
@@ -52,8 +52,8 @@ def pv_table_view(
     # Build side effect function:
     ret_vals = {
         "MY:FLOAT": EpicsData(data=0.5, precision=3,
-                              upper_ctrl_limit=2, lower_ctrl_limit=-2),
-        "MY:INT": EpicsData(data=1, upper_ctrl_limit=10, lower_ctrl_limit=-10),
+                              lower_ctrl_limit=-2, upper_ctrl_limit=2),
+        "MY:INT": EpicsData(data=1, lower_ctrl_limit=-10, upper_ctrl_limit=10),
         "MY:ENUM": EpicsData(data=0, enums=["OUT", "IN", "UNKNOWN"])
     }
 

--- a/superscore/ui/collection_builder_page.ui
+++ b/superscore/ui/collection_builder_page.ui
@@ -60,8 +60,8 @@
       <property name="orientation">
        <enum>Qt::Vertical</enum>
       </property>
-      <widget class="QTableView" name="sub_pv_table_view"/>
-      <widget class="QTableView" name="sub_coll_table_view"/>
+      <widget class="LivePVTableView" name="sub_pv_table_view"/>
+      <widget class="NestableTableView" name="sub_coll_table_view"/>
       <widget class="QTabWidget" name="add_tab_widget">
        <property name="currentIndex">
         <number>0</number>
@@ -202,6 +202,18 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>LivePVTableView</class>
+   <extends>QTableView</extends>
+   <header>superscore.widgets.views</header>
+  </customwidget>
+  <customwidget>
+   <class>NestableTableView</class>
+   <extends>QTableView</extends>
+   <header>superscore.widgets.views</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/superscore/widgets/page/collection_builder.py
+++ b/superscore/widgets/page/collection_builder.py
@@ -86,7 +86,7 @@ class CollectionBuilderPage(Display, DataWidget):
         self.sub_coll_table_view.client = self.client
         self.sub_coll_table_view.set_data(self.data)
 
-        self.tree_model = RootTree(base_entry=self.data)
+        self.tree_model = RootTree(base_entry=self.data, client=self.client)
         self.tree_view.setModel(self.tree_model)
         self.sub_coll_table_view.data_updated.connect(self.tree_model.refresh_tree)
         self.sub_pv_table_view.data_updated.connect(self.tree_model.refresh_tree)

--- a/superscore/widgets/page/collection_builder.py
+++ b/superscore/widgets/page/collection_builder.py
@@ -9,9 +9,9 @@ from superscore.model import Collection, Entry, Parameter
 from superscore.widgets.core import DataWidget, Display, NameDescTagsWidget
 from superscore.widgets.enhanced import FilterComboBox
 from superscore.widgets.manip_helpers import insert_widget
-from superscore.widgets.views import (BaseTableEntryModel, ButtonDelegate,
-                                      LivePVHeader, LivePVTableModel,
-                                      NestableTableModel, RootTree)
+from superscore.widgets.views import (BaseTableEntryModel, LivePVHeader,
+                                      LivePVTableView, NestableTableView,
+                                      RootTree)
 
 logger = logging.getLogger(__name__)
 
@@ -25,14 +25,14 @@ class CollectionBuilderPage(Display, DataWidget):
 
     tree_view: QtWidgets.QTreeView
 
-    sub_coll_table_view: QtWidgets.QTableView
-    sub_pv_table_view: QtWidgets.QTableView
+    sub_coll_table_view: NestableTableView
+    sub_pv_table_view: LivePVTableView
 
     tab_widget: QtWidgets.QTabWidget
     # PV tab
     pv_line_edit: QtWidgets.QLineEdit
     rbv_line_edit: QtWidgets.QLineEdit
-    # Colleciton tab
+    # Collection tab
     add_collection_button: QtWidgets.QPushButton
     coll_combo_box: FilterComboBox
     coll_combo_box_placeholder: QtWidgets.QComboBox
@@ -55,8 +55,6 @@ class CollectionBuilderPage(Display, DataWidget):
         super().__init__(*args, data=data, **kwargs)
         self.client = client
         self.open_page_slot = open_page_slot
-        self.pv_model = None
-        self.coll_model = None
         self.tree_model = None
         self._coll_options: list[Collection] = []
         self._title = self.data.title
@@ -78,30 +76,20 @@ class CollectionBuilderPage(Display, DataWidget):
         self.add_pvs_button.clicked.connect(self.add_pv)
         self.ro_checkbox.stateChanged.connect(self.set_rbv_enabled)
 
-        self.update_model_data()
+        # set up views
+        self.sub_pv_table_view.client = self.client
+        self.sub_pv_table_view.set_data(self.data)
+        for i in [LivePVHeader.STORED_VALUE, LivePVHeader.STORED_SEVERITY,
+                  LivePVHeader.STORED_STATUS]:
+            self.sub_pv_table_view.setColumnHidden(i, True)
 
-        # Configure button delegates
-        self.pv_open_delegate = ButtonDelegate(button_text='open details')
-        self.sub_pv_table_view.setItemDelegateForColumn(LivePVHeader.OPEN,
-                                                        self.pv_open_delegate)
-        self.pv_open_delegate.clicked.connect(self.open_sub_pv_row)
+        self.sub_coll_table_view.client = self.client
+        self.sub_coll_table_view.set_data(self.data)
 
-        self.pv_remove_delegate = ButtonDelegate(button_text='remove')
-        self.sub_pv_table_view.setItemDelegateForColumn(LivePVHeader.REMOVE,
-                                                        self.pv_remove_delegate)
-        self.pv_remove_delegate.clicked.connect(self.remove_sub_pv_row)
-
-        self.nest_open_delegate = ButtonDelegate(button_text='open details')
-        self.sub_coll_table_view.setItemDelegateForColumn(
-            3, self.nest_open_delegate
-        )
-        self.nest_open_delegate.clicked.connect(self.open_sub_coll_row)
-
-        self.nest_remove_delegate = ButtonDelegate(button_text='remove')
-        self.sub_coll_table_view.setItemDelegateForColumn(
-            4, self.nest_remove_delegate
-        )
-        self.nest_remove_delegate.clicked.connect(self.remove_sub_coll_row)
+        self.tree_model = RootTree(base_entry=self.data)
+        self.tree_view.setModel(self.tree_model)
+        self.sub_coll_table_view.data_updated.connect(self.tree_model.refresh_tree)
+        self.sub_pv_table_view.data_updated.connect(self.tree_model.refresh_tree)
 
     def _update_title(self):
         """Set title attribute for access by containing widgets"""
@@ -115,24 +103,6 @@ class CollectionBuilderPage(Display, DataWidget):
             entry = model.entries[index.row()]
             self.open_page_slot(entry)
 
-    def open_sub_pv_row(self, index: QtCore.QModelIndex) -> None:
-        self.open_row_details(self.pv_model, index)
-
-    def open_sub_coll_row(self, index: QtCore.QModelIndex) -> None:
-        self.open_row_details(self.coll_model, index)
-
-    def remove_entry(self, entry: Entry) -> None:
-        self.data.children.remove(entry)
-        self.update_model_data()
-
-    def remove_sub_pv_row(self, index: QtCore.QModelIndex) -> None:
-        entry = self.pv_model.entries[index.row()]
-        self.remove_entry(entry)
-
-    def remove_sub_coll_row(self, index: QtCore.QModelIndex) -> None:
-        entry = self.coll_model.entries[index.row()]
-        self.remove_entry(entry)
-
     def set_rbv_enabled(self, state: int):
         """Disable RBV line edit if read-only checkbox is enabled"""
         self.rbv_line_edit.clear()
@@ -140,44 +110,11 @@ class CollectionBuilderPage(Display, DataWidget):
 
     def update_model_data(self):
         """
-        Update the model data.  If no models exist, initialize new ones.
-        If models have already been initialized,
+        Update the model data.  Signal the models to re-read the data
         """
-        # tree model
-        if self.tree_model is None:
-            self.tree_model = RootTree(base_entry=self.data)
-            self.tree_view.setModel(self.tree_model)
-        else:
-            self.tree_model.refresh_tree()
-
-        # initialize tables
-        self.sub_colls = [child for child in self.data.children
-                          if isinstance(child, Collection)]
-        self.sub_pvs = [child for child in self.data.children
-                        if not isinstance(child, Collection)]
-
-        logger.debug(f"Updating view with {len(self.sub_pvs)} parameters "
-                     f"and {len(self.sub_colls)} collections")
-
-        # PVEntry model
-        if self.pv_model is None:
-            self.pv_model = LivePVTableModel(entries=self.sub_pvs, client=self.client)
-            self.sub_pv_table_view.setModel(self.pv_model)
-
-            # TODO: un-hard code this once there is a better way of managing columns
-            # Potentially dealing with columns that have moved
-            for i in [LivePVHeader.STORED_VALUE, LivePVHeader.STORED_SEVERITY,
-                      LivePVHeader.STORED_STATUS]:
-                self.sub_pv_table_view.setColumnHidden(i, True)
-        else:
-            self.pv_model.set_entries(self.sub_pvs)
-
-        # Nestable Model
-        if self.coll_model is None:
-            self.coll_model = NestableTableModel(entries=self.sub_colls)
-            self.sub_coll_table_view.setModel(self.coll_model)
-        else:
-            self.coll_model.set_entries(self.sub_colls)
+        self.tree_model.refresh_tree()
+        self.sub_pv_table_view.set_data(self.data)
+        self.sub_coll_table_view.set_data(self.data)
 
     def save_collection(self):
         """Save current collection to database via Client"""
@@ -246,5 +183,5 @@ class CollectionBuilderPage(Display, DataWidget):
 
     def closeEvent(self, a0: QCloseEvent) -> None:
         logger.debug("Stopping pv_model polling")
-        self.pv_model.stop_polling(wait_time=5000)
+        self.sub_pv_table_view._model.stop_polling(wait_time=5000)
         return super().closeEvent(a0)

--- a/superscore/widgets/page/collection_builder.py
+++ b/superscore/widgets/page/collection_builder.py
@@ -118,8 +118,8 @@ class CollectionBuilderPage(Display, DataWidget):
 
     def save_collection(self):
         """Save current collection to database via Client"""
-        self.data.title = self.meta_widget.name_edit.text(),
-        self.data.description = self.meta_widget.desc_edit.toPlainText(),
+        self.data.title = self.meta_widget.name_edit.text()
+        self.data.description = self.meta_widget.desc_edit.toPlainText()
         # children should have been updated along the way
         self.client.save(self.data)
         logger.info(f"Collection saved ({self.data.uuid})")

--- a/superscore/widgets/page/collection_builder.py
+++ b/superscore/widgets/page/collection_builder.py
@@ -82,6 +82,7 @@ class CollectionBuilderPage(Display, DataWidget):
         for i in [LivePVHeader.STORED_VALUE, LivePVHeader.STORED_SEVERITY,
                   LivePVHeader.STORED_STATUS]:
             self.sub_pv_table_view.setColumnHidden(i, True)
+        self.sub_pv_table_view.set_editable(LivePVHeader.PV_NAME, True)
 
         self.sub_coll_table_view.client = self.client
         self.sub_coll_table_view.set_data(self.data)

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -567,7 +567,7 @@ class BaseTableEntryModel(QtCore.QAbstractTableModel):
             the ItemFlag corresponding to the cell
         """
         if index.column() not in self._editable_cols:
-            return
+            return QtCore.Qt.ItemIsEnabled
 
         if self._editable_cols[index.column()]:
             return QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsEditable

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -566,6 +566,9 @@ class BaseTableEntryModel(QtCore.QAbstractTableModel):
         QtCore.Qt.ItemFlag
             the ItemFlag corresponding to the cell
         """
+        if index.column() not in self._editable_cols:
+            return
+
         if self._editable_cols[index.column()]:
             return QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsEditable
         else:

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -911,7 +911,7 @@ class LivePVTableModel(BaseTableEntryModel):
             # data still fetching, don't compare
             return
 
-        if hasattr(e_data, "enums") and isinstance(data, int):
+        if hasattr(e_data, "enums") and e_data.enums and isinstance(data, int):
             # Unify enum representation
             r_data = e_data.enums[data]
             l_data = e_data.enums[e_data.data]
@@ -1365,15 +1365,23 @@ class ValueDelegate(QtWidgets.QStyledItemDelegate):
                 widget.setCurrentIndex(data_val.data)
             elif isinstance(data_val.data, int):
                 widget = QtWidgets.QSpinBox(parent)
+                if data_val.lower_ctrl_limit == 0 and data_val.upper_ctrl_limit == 0:
+                    widget.setMaximum(2147483647)
+                    widget.setMinimum(-2147483647)
+                else:
+                    widget.setMaximum(data_val.upper_ctrl_limit)
+                    widget.setMinimum(data_val.lower_ctrl_limit)
                 widget.setValue(data_val.data)
-                widget.setMaximum(data_val.upper_ctrl_limit)
-                widget.setMinimum(data_val.lower_ctrl_limit)
             elif isinstance(data_val.data, float):
                 widget = QtWidgets.QDoubleSpinBox(parent)
-                widget.setValue(data_val.data)
-                widget.setMaximum(data_val.upper_ctrl_limit)
-                widget.setMinimum(data_val.lower_ctrl_limit)
+                if data_val.lower_ctrl_limit == 0 and data_val.upper_ctrl_limit == 0:
+                    widget.setMaximum(2147483647)
+                    widget.setMinimum(-2147483647)
+                else:
+                    widget.setMaximum(data_val.upper_ctrl_limit)
+                    widget.setMinimum(data_val.lower_ctrl_limit)
                 widget.setDecimals(data_val.precision)
+                widget.setValue(data_val.data)
         else:
             logger.debug(f"datatype ({dtype}) incompatible with supported edit "
                          f"widgets: ({data_val})")

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -1096,11 +1096,21 @@ class BaseDataTableView(QtWidgets.QTableView):
                 f"Attempted to set an incompatable data type ({type(data)})"
             )
         self.data = data
-        self.gather_sub_entries()
+        self.maybe_setup_model()
 
+    def maybe_setup_model(self):
+        """
+        Set up the model if data and client are set
+        """
         if self.client is None:
-            logger.debug("Client not yet set, cannot initialize model")
+            logger.debug("Client not set, cannot initialize model")
             return
+
+        if self.data is None:
+            logger.debug("data not set, cannot initialize model")
+            return
+
+        self.gather_sub_entries()
 
         if self._model is None:
             self._model = self._model_cls(
@@ -1137,6 +1147,7 @@ class BaseDataTableView(QtWidgets.QTableView):
             raise ValueError("Provided client is not a superscore Client")
 
         self._client = client
+        self.maybe_setup_model()
 
     def set_editable(self, column: int, is_editable: bool) -> None:
         if not self._model:
@@ -1359,7 +1370,7 @@ class ValueDelegate(QtWidgets.QStyledItemDelegate):
             data_val: EpicsData = index.model().data(
                 index, role=CustRoles.EpicsDataRole
             )
-            if isinstance(data_val, str):
+            if not isinstance(data_val, EpicsData):
                 # not yet initialized, no-op
                 return
             if isinstance(data_val.data, str):


### PR DESCRIPTION
## Description
- Refactors shared table models to have their own self-contained table views for ease of use and extensibility
- Add methods to make columns editable for both shared table models
- Adds ValueDelegate to provide constrained editing for columns based on their datatype and metadata
- Add more metadata fields to EpicsData (precision, enums, limits, precision)
- improve enum handling for `LivePVTableView`

## Motivation and Context
Going about adding more functionality.

## How Has This Been Tested?
Interactively, ensuring existing tests run

## Where Has This Been Documented?
This PR
enum ValueDelegate
<img width="758" alt="image" src="https://github.com/user-attachments/assets/e0eb3c26-8569-4b6a-930e-a73987089cd0">

double ValueDelegate (must be < 0)
<img width="760" alt="image" src="https://github.com/user-attachments/assets/4b43362b-6118-4b09-8db4-c185ccb9a3df">


## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
