### PR TITLE
ENH: add snapshot view / compare / restore page (only view functional)

### DIFF
--- a/docs/source/upcoming_release_notes/94-snapshot_restore_page.rst
+++ b/docs/source/upcoming_release_notes/94-snapshot_restore_page.rst
@@ -1,0 +1,25 @@
+94 snapshot restore page
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- add restore page: shows all non-Nestable Entries within a Snapshot, can compare to live data
+- restore page can be opened through the tree view context menu
+- middle clicking on a BaseDataTableView cell copies the contents to the clipboard
+- double clicking a TreeView item opens the detailed Entry page
+
+Bugfixes
+--------
+- stop LivePVTableModel polling before clearing data, to avoid accessing deleted data
+
+Maintenance
+-----------
+- increase main windows's default size
+
+Contributors
+------------
+- shilorigins

--- a/superscore/bin/main.py
+++ b/superscore/bin/main.py
@@ -13,6 +13,9 @@ from inspect import iscoroutinefunction
 
 import superscore
 
+logger = logging.getLogger('superscore')
+
+
 DESCRIPTION = __doc__
 MODULES = ("help", "ui", "demo")
 
@@ -37,18 +40,13 @@ def _build_commands():
             DESCRIPTION += f'\n    $ superscore {module} --help'
 
     if unavailable:
-        DESCRIPTION += '\n\n'
-
         for module, ex in unavailable:
-            DESCRIPTION += (
-                f'\nWARNING: "superscore {module}" is unavailable due to:'
+            logger.warning(
+                f'WARNING: "{module}" subcommand is unavailable due to:'
                 f'\n\t{ex.__class__.__name__}: {ex}'
             )
 
     return result
-
-
-COMMANDS = _build_commands()
 
 
 def main():
@@ -73,6 +71,7 @@ def main():
     )
 
     subparsers = top_parser.add_subparsers(help='Possible subcommands')
+    COMMANDS = _build_commands()
     for command_name, (build_func, main) in COMMANDS.items():
         sub = subparsers.add_parser(command_name)
         build_func(sub)
@@ -82,10 +81,7 @@ def main():
     kwargs = vars(args)
     log_level = kwargs.pop('log_level')
 
-    logger = logging.getLogger('superscore')
     logger.setLevel(log_level)
-    logging.basicConfig()
-
     if hasattr(args, 'func'):
         func = kwargs.pop('func')
         logger.debug('%s(**%r)', func.__name__, kwargs)

--- a/superscore/bin/ui.py
+++ b/superscore/bin/ui.py
@@ -10,6 +10,9 @@ from qtpy.QtWidgets import QApplication
 from superscore.client import Client
 from superscore.widgets.window import Window
 
+DEFAULT_WIDTH = 1400
+DEFAULT_HEIGHT = 800
+
 
 def build_arg_parser(argparser=None):
     if argparser is None:
@@ -22,5 +25,11 @@ def main(*args, client: Optional[Client] = None, **kwargs):
     app = QApplication(sys.argv)
     main_window = Window(client=client)
 
+    primary_screen = app.screens()[0]
+    center = primary_screen.geometry().center()
+    # move window rather creating a QRect because we want to include the frame geometry
+    main_window.setGeometry(0, 0, DEFAULT_WIDTH, DEFAULT_HEIGHT)
+    delta = main_window.geometry().center()
+    main_window.move(center - delta)
     main_window.show()
     app.exec()

--- a/superscore/tests/conftest.py
+++ b/superscore/tests/conftest.py
@@ -12,7 +12,7 @@ from superscore.client import Client
 from superscore.control_layers._base_shim import _BaseShim
 from superscore.control_layers.core import ControlLayer
 from superscore.model import (Collection, Parameter, Readback, Root, Setpoint,
-                              Snapshot)
+                              Severity, Snapshot, Status)
 from superscore.tests.ioc import IOCFactory
 
 
@@ -311,6 +311,8 @@ def linac_data():
         pv_name=lasr_gunb_pv1.pv_name,
         description=lasr_gunb_pv1.description,
         data="Off",
+        status=Status.NO_ALARM,
+        severity=Severity.NO_ALARM,
     )
 
     now = lasr_gunb_value1.creation_time
@@ -321,6 +323,8 @@ def linac_data():
         description=lasr_gunb_pv2.description,
         creation_time=now,
         data=5,
+        status=Status.NO_ALARM,
+        severity=Severity.NO_ALARM,
     )
 
     lasr_gunb_snapshot = Snapshot(
@@ -340,6 +344,8 @@ def linac_data():
         description=mgnt_gunb_pv.description,
         creation_time=now,
         data=True,
+        status=Status.NO_ALARM,
+        severity=Severity.NO_ALARM,
     )
 
     mgnt_gunb_snapshot = Snapshot(
@@ -358,6 +364,8 @@ def linac_data():
         description=vac_gunb_pv1.description,
         creation_time=now,
         data="Ion Pump",
+        status=Status.NO_ALARM,
+        severity=Severity.NO_ALARM,
     )
 
     vac_gunb_value2 = Setpoint(
@@ -366,6 +374,8 @@ def linac_data():
         description=vac_gunb_pv2.description,
         creation_time=now,
         data=False,
+        status=Status.NO_ALARM,
+        severity=Severity.NO_ALARM,
     )
 
     vac_gunb_snapshot = Snapshot(
@@ -397,6 +407,8 @@ def linac_data():
         description=vac_l0b_pv.description,
         creation_time=now,
         data=-10,
+        status=Status.NO_ALARM,
+        severity=Severity.NO_ALARM,
     )
 
     vac_l0b_snapshot = Snapshot(
@@ -425,6 +437,8 @@ def linac_data():
         description=vac_bsy_pv.description,
         creation_time=now,
         data="",
+        status=Status.NO_ALARM,
+        severity=Severity.NO_ALARM,
     )
 
     vac_bsy_snapshot = Snapshot(
@@ -465,6 +479,8 @@ def linac_data():
         description=vac_li10_pv.description,
         creation_time=now,
         data=.25,
+        status=Status.NO_ALARM,
+        severity=Severity.NO_ALARM,
     )
 
     vac_li10_snapshot = Snapshot(
@@ -493,6 +509,8 @@ def linac_data():
         description=lasr_in10_pv.description,
         creation_time=now,
         data=645.26,
+        status=Status.NO_ALARM,
+        severity=Severity.NO_ALARM,
     )
 
     lasr_in10_snapshot = Snapshot(
@@ -532,6 +550,8 @@ def linac_data():
         description=lasr_in20_pv.description,
         creation_time=now,
         data=0,
+        status=Status.NO_ALARM,
+        severity=Severity.NO_ALARM,
     )
 
     lasr_in20_snapshot = Snapshot(
@@ -560,6 +580,8 @@ def linac_data():
         description=vac_li21_pv.description,
         creation_time=now,
         data=0.0,
+        status=Status.NO_ALARM,
+        severity=Severity.NO_ALARM,
     )
 
     vac_li21_setpoint = Setpoint(
@@ -568,6 +590,8 @@ def linac_data():
         description=vac_li21_pv.description,
         creation_time=now,
         data=5.0,
+        status=Status.NO_ALARM,
+        severity=Severity.NO_ALARM,
         readback=vac_li21_readback,
     )
 

--- a/superscore/tests/test_page.py
+++ b/superscore/tests/test_page.py
@@ -230,14 +230,14 @@ def test_stored_widget_swap(
         )
 
 
-def test_restore_page_toggle_live(restore_page):
+def test_restore_page_toggle_live(qtbot: QtBot, restore_page):
     tableView = restore_page.tableView
     live_columns = tableView.live_headers
     toggle_live_button = restore_page.compareLiveButton
 
     toggle_live_button.click()
-    assert tableView._model._poll_thread.running
-    assert all((not tableView.isColumnHidden(column) for column in live_columns))
+    qtbot.waitUntil(lambda: tableView._model._poll_thread.running)
+    qtbot.waitUntil(lambda: all((not tableView.isColumnHidden(column) for column in live_columns)))
 
     toggle_live_button.click()
-    assert all((tableView.isColumnHidden(column) for column in live_columns))
+    qtbot.waitUntil(lambda: all((tableView.isColumnHidden(column) for column in live_columns)))

--- a/superscore/ui/restore_page.ui
+++ b/superscore/ui/restore_page.ui
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>878</width>
+    <height>539</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_3">
+   <item row="0" column="0">
+    <widget class="QFrame" name="headerFrame">
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0,0,0,0,0">
+      <item row="0" column="4">
+       <spacer name="headerSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="5">
+       <widget class="QPushButton" name="compareLiveButton">
+        <property name="text">
+         <string>Compare to Live</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="6">
+       <widget class="QPushButton" name="compareSnapshotButton">
+        <property name="text">
+         <string>Compare to Snapshot</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="primarySnapshotLabel">
+          <property name="text">
+           <string>#####</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLabel" name="primarySnapshotTitle">
+          <property name="text">
+           <string>#####</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="secondarySnapshotLabel">
+          <property name="text">
+           <string>#####</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLabel" name="secondarySnapshotTitle">
+          <property name="text">
+           <string>#####</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="SnapshotTableView" name="tableView"/>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>SnapshotTableView</class>
+   <extends>QTableView</extends>
+   <header location="global">superscore.widgets.page.restore</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/superscore/ui/restore_page.ui
+++ b/superscore/ui/restore_page.ui
@@ -37,7 +37,7 @@
        </spacer>
       </item>
       <item row="0" column="5">
-       <widget class="QPushButton" name="compareLiveButton">
+       <widget class="LiveButton" name="compareLiveButton">
         <property name="text">
          <string>Compare to Live</string>
         </property>
@@ -94,6 +94,11 @@
   <customwidget>
    <class>SnapshotTableView</class>
    <extends>QTableView</extends>
+   <header>superscore.widgets.page.restore</header>
+  </customwidget>
+  <customwidget>
+   <class>LiveButton</class>
+   <extends>QPushButton</extends>
    <header location="global">superscore.widgets.page.restore</header>
   </customwidget>
  </customwidgets>

--- a/superscore/widgets/page/restore.py
+++ b/superscore/widgets/page/restore.py
@@ -9,9 +9,19 @@ from qtpy.QtGui import QCloseEvent
 from superscore.client import Client
 from superscore.model import Snapshot
 from superscore.widgets.core import Display
-from superscore.widgets.views import LivePVHeader, LivePVTableView
+from superscore.widgets.views import (LivePVHeader, LivePVTableModel,
+                                      LivePVTableView)
 
 logger = logging.getLogger(__name__)
+
+
+class SnapshotTableModel(LivePVTableModel):
+    """Model specific to showing and comparing PVs in Snapshots"""
+    def data(self, index: QtCore.QModelIndex, role: int):
+        if role == QtCore.Qt.TextAlignmentRole:
+            return QtCore.Qt.AlignCenter
+        else:
+            return super().data(index, role)
 
 
 class SnapshotTableView(LivePVTableView):
@@ -23,6 +33,7 @@ class SnapshotTableView(LivePVTableView):
 
     def __init__(self, *args, start_live: bool = False, **kwargs):
         super().__init__(*args, **kwargs)
+        self._model_cls = SnapshotTableModel
         self._is_live = start_live
 
     def gather_sub_entries(self) -> None:

--- a/superscore/widgets/page/restore.py
+++ b/superscore/widgets/page/restore.py
@@ -1,0 +1,78 @@
+"""Page for inspecting, comparing, and restoring Snapshot values"""
+
+import logging
+from functools import partial
+
+from qtpy import QtWidgets
+from qtpy.QtGui import QCloseEvent
+
+from superscore.client import Client
+from superscore.model import Snapshot
+from superscore.widgets.core import Display
+from superscore.widgets.views import LivePVHeader, LivePVTableView
+
+logger = logging.getLogger(__name__)
+
+
+class SnapshotTableView(LivePVTableView):
+    """Table view specific to showing and comparing PVs in Snapshots"""
+    live_headers = {LivePVHeader.LIVE_VALUE, LivePVHeader.LIVE_STATUS, LivePVHeader.LIVE_SEVERITY}
+
+    def gather_sub_entries(self) -> None:
+        self.sub_entries = self.client._gather_leaves(self.data)
+
+
+class RestorePage(Display, QtWidgets.QWidget):
+    """A page for inspecting, comparing, and restoring Snapshot PV values"""
+
+    filename = 'restore_page.ui'
+
+    headerFrame: QtWidgets.QFrame
+    primarySnapshotLabel: QtWidgets.QLabel
+    primarySnapshotTitle: QtWidgets.QLabel
+    secondarySnapshotLabel: QtWidgets.QLabel
+    secondarySnapshotTitle: QtWidgets.QLabel
+    compareLiveButton: QtWidgets.QPushButton
+    compareSnapshotButton: QtWidgets.QPushButton
+
+    tableView: SnapshotTableView
+
+    def __init__(
+        self,
+        *args,
+        data: Snapshot,
+        client: Client,
+        **kwargs,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.client = client
+
+        self.snapshot = data
+        self.tableView.client = self.client
+        self.tableView.set_data(data)
+        self.tableView.hideColumn(LivePVHeader.REMOVE)
+        self.set_live(False)
+        header = self.tableView.horizontalHeader()
+        header.setSectionResizeMode(header.Stretch)
+
+        self.primarySnapshotLabel.setText("Viewing:")
+        self.primarySnapshotTitle.setText(data.title)
+        self.secondarySnapshotLabel.setText("Comparing:")
+        self.secondarySnapshotLabel.hide()
+        self.secondarySnapshotTitle.hide()
+
+    def set_live(self, is_live: bool):
+        for live_header in self.tableView.live_headers:
+            self.tableView.setColumnHidden(live_header, not is_live)
+
+        self.compareLiveButton.setText(["Compare to Live", "Turn off Live"][int(is_live)])
+        self.compareLiveButton.clicked.connect(partial(self.set_live, not is_live))
+
+        self.secondarySnapshotLabel.setVisible(is_live)
+        self.secondarySnapshotTitle.setText("Live Data")
+        self.secondarySnapshotTitle.setVisible(is_live)
+
+    def closeEvent(self, a0: QCloseEvent) -> None:
+        logging.debug("Closing SnapshotTableView")
+        self.tableView.close()
+        super().closeEvent(a0)

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -1155,6 +1155,19 @@ class BaseDataTableView(QtWidgets.QTableView):
             return
         self._model.set_editable(column, is_editable)
 
+    def mousePressEvent(self, event: QtGui.QMouseEvent) -> None:
+        if event.button() == QtCore.Qt.MiddleButton:
+            index = self.indexAt(event.position().toPoint())
+            text = self._model.data(index, QtCore.Qt.DisplayRole)
+            clipboard = QtWidgets.QApplication.clipboard()
+            if clipboard.supportsSelection():
+                mode = clipboard.Selection
+            else:
+                mode = clipboard.Clipboard
+            clipboard.setText(text, mode=mode)
+            clipboard.setText(text)
+        super().mousePressEvent(event)
+
 
 class LivePVTableView(BaseDataTableView):
     """

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -847,11 +847,11 @@ class LivePVTableModel(BaseTableEntryModel):
             return stored_data
         elif index.column() == LivePVHeader.LIVE_VALUE:
             live_value = self._get_live_data_field(entry, 'data')
-            stored_data = getattr(entry, 'data', None)
-            is_close = self.is_close(entry, stored_data)
-            if ((stored_data is not None) and role == QtCore.Qt.BackgroundRole
-                    and not is_close):
-                return QtGui.QColor('red')
+            if role == QtCore.Qt.BackgroundRole:
+                stored_data = getattr(entry, 'data', None)
+                is_close = self.is_close(entry, stored_data)
+                if stored_data is not None and not is_close:
+                    return QtGui.QColor('red')
             return str(live_value)
         elif index.column() == LivePVHeader.TIMESTAMP:
             return entry.creation_time.strftime('%Y/%m/%d %H:%M')

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -700,11 +700,10 @@ class LivePVTableModel(BaseTableEntryModel):
 
         logger.debug(f"stopping and de-referencing thread @ {id(self._poll_thread)}")
         # does not remove reference to avoid premature python garbage collection
-        self._poll_thread.data = {}
         self._poll_thread.stop()
-
         if wait_time > 0.0:
             self._poll_thread.wait(wait_time)
+        self._poll_thread.data = {}
 
     @QtCore.Slot()
     def _poll_thread_finished(self):

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -1222,6 +1222,11 @@ class LivePVTableView(BaseDataTableView):
             self._model.client = self._client
             self._model.start_polling()
 
+    def closeEvent(self, a0: QtGui.QCloseEvent) -> None:
+        logger.debug("Stopping pv_model polling")
+        self._model.stop_polling(wait_time=5000)
+        super().closeEvent(a0)
+
 
 class NestableHeader(HeaderEnum):
     NAME = 0

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -13,11 +13,12 @@ from qtpy import QtCore, QtWidgets
 from qtpy.QtGui import QCloseEvent
 
 from superscore.client import Client
-from superscore.model import Entry
+from superscore.model import Entry, Snapshot
 from superscore.widgets import ICON_MAP
 from superscore.widgets.core import DataWidget, Display
 from superscore.widgets.page import PAGE_MAP
 from superscore.widgets.page.collection_builder import CollectionBuilderPage
+from superscore.widgets.page.restore import RestorePage
 from superscore.widgets.page.search import SearchPage
 from superscore.widgets.views import RootTree
 
@@ -135,7 +136,13 @@ class Window(Display, QtWidgets.QMainWindow):
 
     def open_search_page(self) -> None:
         page = SearchPage(client=self.client, open_page_slot=self.open_page)
-        self.tab_widget.addTab(page, 'search')
+        index = self.tab_widget.addTab(page, 'search')
+        self.tab_widget.setCurrentIndex(index)
+
+    def open_restore_page(self, snapshot: Snapshot) -> None:
+        page = RestorePage(data=snapshot, client=self.client)
+        index = self.tab_widget.addTab(page, snapshot.title)
+        self.tab_widget.setCurrentIndex(index)
 
     def _tree_context_menu(self, pos: QtCore.QPoint) -> None:
         self.menu = QtWidgets.QMenu(self)
@@ -147,6 +154,9 @@ class Window(Display, QtWidgets.QMainWindow):
             )
             # WeakPartialMethodSlot may not be needed, menus are transient
             open_action.triggered.connect(partial(self.open_page, entry))
+            if isinstance(entry, Snapshot):
+                restore_page_action = self.menu.addAction('Inspect values')
+                restore_page_action.triggered.connect(partial(self.open_restore_page, entry))
         self.menu.exec_(self.tree_view.mapToGlobal(pos))
 
     def closeEvent(self, a0: QCloseEvent) -> None:

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -24,9 +24,6 @@ from superscore.widgets.views import RootTree
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_WIDTH = 1400
-DEFAULT_HEIGHT = 800
-
 
 class Window(Display, QtWidgets.QMainWindow):
     """Main superscore window"""
@@ -47,8 +44,6 @@ class Window(Display, QtWidgets.QMainWindow):
 
         self._partial_slots = []
 
-        self.resize(DEFAULT_WIDTH, DEFAULT_HEIGHT)
-        self.move(self.screen().geometry().center() - self.frameGeometry().center())
         self.setup_ui()
         self.open_search_page()
 

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -24,6 +24,9 @@ from superscore.widgets.views import RootTree
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_WIDTH = 1400
+DEFAULT_HEIGHT = 800
+
 
 class Window(Display, QtWidgets.QMainWindow):
     """Main superscore window"""
@@ -44,6 +47,8 @@ class Window(Display, QtWidgets.QMainWindow):
 
         self._partial_slots = []
 
+        self.resize(DEFAULT_WIDTH, DEFAULT_HEIGHT)
+        self.move(self.screen().geometry().center() - self.frameGeometry().center())
         self.setup_ui()
         self.open_search_page()
 

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -58,6 +58,7 @@ class Window(Display, QtWidgets.QMainWindow):
         self.tree_view.setModel(self.tree_model)
         self.tree_view.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         self.tree_view.customContextMenuRequested.connect(self._tree_context_menu)
+        self.tree_view.setExpandsOnDoubleClick(False)
         self.tree_view.doubleClicked.connect(self.open_index)
 
         # setup actions

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -4,6 +4,7 @@ Top-level window widget that contains other widgets
 from __future__ import annotations
 
 import logging
+from functools import partial
 from typing import Optional
 
 import qtawesome as qta
@@ -139,18 +140,13 @@ class Window(Display, QtWidgets.QMainWindow):
     def _tree_context_menu(self, pos: QtCore.QPoint) -> None:
         self.menu = QtWidgets.QMenu(self)
         index: QtCore.QModelIndex = self.tree_view.indexAt(pos)
-        entry: Entry = index.internalPointer()._data
-
         if index is not None and index.data() is not None:
-            # WeakPartialMethodSlot may not be needed, menus are transient
-            def open(*_, **__):
-                self.open_page(entry)
-
+            entry: Entry = index.internalPointer()._data
             open_action = self.menu.addAction(
                 f'&Open Detailed {type(entry).__name__} page'
             )
-            open_action.triggered.connect(open)
-
+            # WeakPartialMethodSlot may not be needed, menus are transient
+            open_action.triggered.connect(partial(self.open_page, entry))
         self.menu.exec_(self.tree_view.mapToGlobal(pos))
 
     def closeEvent(self, a0: QCloseEvent) -> None:

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -58,6 +58,7 @@ class Window(Display, QtWidgets.QMainWindow):
         self.tree_view.setModel(self.tree_model)
         self.tree_view.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
         self.tree_view.customContextMenuRequested.connect(self._tree_context_menu)
+        self.tree_view.doubleClicked.connect(self.open_index)
 
         # setup actions
         self.action_new_coll.triggered.connect(self.open_collection_builder)
@@ -125,6 +126,10 @@ class Window(Display, QtWidgets.QMainWindow):
         self.tab_widget.setCurrentIndex(idx)
 
         return page_widget
+
+    def open_index(self, index: QtCore.QModelIndex) -> None:
+        entry: Entry = index.internalPointer()._data
+        self.open_page(entry)
 
     def open_search_page(self) -> None:
         page = SearchPage(client=self.client, open_page_slot=self.open_page)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add restore page template and logic
Add ability to open restore page from root tree `QTreeView`
Increase default size of the main window
Fix bug where closing a `LivePVTableModel` sometimes causes an error trying to access deleted data

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This page can currently show all leaf `Entry`s in a snapshot and can compare stored values to live values.  The same page is intended to be able to compare values from two snapshots and to restore saved values, but both of those capabilities are postponed for later PRs.

The AD control system has a convention where middle clicking on a UI element shows the underlying PV and copies it to the clipboard, so I added middle-click-to-copy as a partial implementation and convenience feature.  We can fill out the PV-display-and-copy later if desired. 

~Double-clicking an entry on the tree view opens the entry page and no longer expands the tree item because I found that use case intuitive, and items can still be expanded by clicking on the items' arrows.  Happy to alter this functionality if doing so would be more usable.~
Since the `Snapshot` entry page is now associated with the tree view's double-click, I added an action to open the restore page to the tree view's context menu.

I increased the size of the main window to better show the data-dense tables without having to manually expand the window every time.  I didn't optimize the new size, but it works well enough on my dev monitor and laptop.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively.
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Screenshots:
Page when a snapshot is opened:
![Screenshot 2024-10-23 at 15 56 24](https://github.com/user-attachments/assets/a726a689-7d4c-48c1-b9cb-ef3816c65dbf)

Page when `Compare to Live` button is clicked:
![Screenshot 2024-10-23 at 15 56 36](https://github.com/user-attachments/assets/34a16c53-2374-481a-a705-ed1c1cf94b31)


## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
