### PR TITLE
FIX: actually fill child entries in shared table views

### DIFF
--- a/docs/source/upcoming_release_notes/96-fix_fill_child_view.rst
+++ b/docs/source/upcoming_release_notes/96-fix_fill_child_view.rst
@@ -1,0 +1,22 @@
+96 fix_fill_child_view
+######################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Fill UUID children when found in LivePVTableView and NestableTableView
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -1195,9 +1195,10 @@ class LivePVTableView(BaseDataTableView):
         if isinstance(self.data, Nestable):
             # gather sub_nestables
             self.sub_entries = []
-            for child in self.data.children:
+            for i, child in enumerate(self.data.children):
                 if isinstance(child, UUID):
                     child = self._client.backend.get_entry(child)
+                    self.data.children[i] = child
                 else:
                     child = child
 
@@ -1301,9 +1302,10 @@ class NestableTableView(BaseDataTableView):
 
         if isinstance(self.data, Nestable):
             # gather sub_nestables
-            for child in self.data.children:
+            for i, child in enumerate(self.data.children):
                 if isinstance(child, UUID):
                     child = self._client.backend.get_entry(child)
+                    self.data.children[i] = child
                 else:
                     child = child
 

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -1197,11 +1197,11 @@ class LivePVTableView(BaseDataTableView):
             self.sub_entries = []
             for child in self.data.children:
                 if isinstance(child, UUID):
-                    filled_child = self._client.backend.get_entry(child)
+                    child = self._client.backend.get_entry(child)
                 else:
-                    filled_child = child
+                    child = child
 
-                if filled_child is None:
+                if child is None:
                     raise EntryNotFoundError(f"{child} not found in backend, "
                                              "cannot fill with real data")
 
@@ -1298,16 +1298,16 @@ class NestableTableView(BaseDataTableView):
     def gather_sub_entries(self):
         if isinstance(self.data, UUID):
             self.data = self.client.backend.get_entry(self.data)
-        # TODO: gather and fill entries where necessary
+
         if isinstance(self.data, Nestable):
             # gather sub_nestables
             for child in self.data.children:
                 if isinstance(child, UUID):
-                    filled_child = self._client.backend.get_entry(child)
+                    child = self._client.backend.get_entry(child)
                 else:
-                    filled_child = child
+                    child = child
 
-                if filled_child is None:
+                if child is None:
                     raise EntryNotFoundError(f"{child} not found in backend, "
                                              "cannot fill with real data")
 


### PR DESCRIPTION
## Description
Actually fill child entries if they are uuids

## Motivation and Context
Originally observed as a bug where entries would not be loaded into tables when you'd expect them to.  Also modifies the parent dataclass, replacing UUIDs with an Entry.  This does not recurse.

## How Has This Been Tested?
Interactively, and some tests were added

## Where Has This Been Documented?
This PR.

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
