### PR TITLE
ENH: add Client.compare, along with dataclass diff calculation utilities

### DIFF
--- a/docs/source/upcoming_release_notes/98-enh_client_compare.rst
+++ b/docs/source/upcoming_release_notes/98-enh_client_compare.rst
@@ -1,0 +1,24 @@
+98 enh_client_compare
+#####################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Adds EntryDiff, which tracks two Entrys, along with a list of DiffItem objects
+- Implements Client.fill for filling Nestable Entry UUID fields
+- Implements Client.compare
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 from superscore.backends import get_backend
 from superscore.backends.core import SearchTerm, SearchTermType, _Backend
+from superscore.compare import EntryDiff, walk_find_diff
 from superscore.control_layers import ControlLayer, EpicsData
 from superscore.control_layers.status import TaskStatus
 from superscore.errors import CommunicationError
@@ -188,7 +189,16 @@ class Client:
 
     def compare(self, entry_l: Entry, entry_r: Entry) -> Any:
         """Compare two entries.  Should be of same type, and return a diff"""
-        raise NotImplementedError
+        if type(entry_l) is not type(entry_r):
+            raise ValueError("The two provided entries are of different types"
+                             f"({type(entry_l).__name__} vs {type(entry_r).__name__})")
+
+        # TODO: fill both entries before comparing
+
+        diffs = walk_find_diff(entry_l, entry_r)
+
+        # TODO: do we want this to be a fully expressed list?  is currently a generator
+        return EntryDiff(original_entry=entry_l, new_entry=entry_r, diffs=list(diffs))
 
     def snap(self, entry: Collection) -> Snapshot:
         """

--- a/superscore/compare.py
+++ b/superscore/compare.py
@@ -6,11 +6,11 @@ from typing import Any, Generator, Iterable, List, Optional, Tuple, Union
 from superscore.model import Entry
 
 # An attribute access path chain leading to the item of interest
-# simple fields:        (object, "field_name")
-# dictionary values:    ("__dict__", "key_name")   ... not used?
+# simple fields:        (dclass_object: dataclass, field_name: str)
+# dictionary values:    ("__dict__", key_name: str)
 # list entry:           ("__list__", list_index: int)
-# enum value:           ("__enum__", Enum.member_object)
-# set entry:            ("__set__", "set_member")
+# enum value:           ("__enum__", enum_member: Enum)
+# set entry:            ("__set__", set_member: str)
 AttributePath = List[Tuple[Any, Any]]
 
 

--- a/superscore/compare.py
+++ b/superscore/compare.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, fields, is_dataclass
+from typing import Any, Generator, Iterable, List, Optional, Tuple, Union
+
+from superscore.model import Entry
+
+# An attribute access path chain leading to the item of interest
+# simple fields:        (object, "field_name")
+# dictionary values:    ("__dict__", "key_name")   ... not used?
+# list entry:           ("__list__", list_index: int)
+# enum value:           ("__enum__", Enum.member_object)
+# set entry:            ("__set__", "set_member")
+AttributePath = List[Tuple[Any, Any]]
+
+
+@dataclass
+class DiffItem:
+    """
+    A single difference, represented by a path to the changed fielid and the
+    new/old values of said field
+    """
+    original_value: Any
+    new_value: Any
+    path: AttributePath
+
+    def __repr__(self) -> str:
+        # assume the first segment is an object
+        if not self.path:
+            repr_str = "()"
+        else:
+            repr_str = f"{type(self.path[0][0]).__name__}"
+
+        for segment in self.path:
+            if segment[0] == "__list__":
+                repr_str += f"[{segment[1]}]"
+            else:
+                # handle simple field
+                repr_str += f".{segment[1]}"
+
+        if isinstance(self.original_value, Entry):
+            orig_val_str = type(self.original_value).__name__
+            new_val_str = type(self.new_value).__name__
+        else:
+            orig_val_str = self.original_value or "(None)"
+            new_val_str = self.new_value or "(None)"
+
+        repr_str += f": ({orig_val_str}->{new_val_str})"
+
+        return repr_str
+
+
+@dataclass
+class EntryDiff:
+    """
+    The difference between original_entry and new_entry, represented by DiffItem's
+    """
+    original_entry: Entry
+    new_entry: Entry
+    diffs: Iterable[DiffItem]
+
+    def __repr__(self) -> str:
+        repr_str = "Diff: {\n"
+        for diff in self.diffs:
+            repr_str += f"    {str(diff)}\n"
+        repr_str += "}"
+
+        return repr_str
+
+
+def walk_find_diff(
+    orig_item: Union[Entry, Any],
+    new_item: Union[Entry, Any],
+    curr_path: Optional[AttributePath] = None,
+) -> Generator[DiffItem, None, None]:
+    if curr_path is None:
+        curr_path = []
+
+    if type(orig_item) is not type(new_item):
+        yield DiffItem(
+            original_value=orig_item,
+            new_value=new_item,
+            path=curr_path,
+        )
+    elif is_dataclass(orig_item):
+        # get fields, recurse through fields
+        orig_fields = {field.name: getattr(orig_item, field.name)
+                       for field in fields(orig_item)}
+
+        new_fields = {field.name: getattr(new_item, field.name)
+                      for field in fields(new_item)}
+        for field_name, field_value in orig_fields.items():
+            if field_name not in new_fields:
+                yield DiffItem(
+                    original_value=field_value,
+                    new_value=None,
+                    path=curr_path + [(orig_item, field_name)],
+                )
+            else:
+                # field name present in both
+                yield from walk_find_diff(
+                    orig_item=getattr(orig_item, field_name),
+                    new_item=getattr(new_item, field_name),
+                    curr_path=curr_path + [(orig_item, field_name)],
+                )
+
+        for new_field_name, new_field_value in new_fields.items():
+            if field_name not in orig_fields:
+                yield DiffItem(
+                    original_value=None,
+                    new_value=new_field_value,
+                    path=curr_path + [(orig_item, new_field_name)],
+                )
+
+    elif isinstance(orig_item, list):
+        num_orig = len(orig_item)
+        num_new = len(new_item)
+        # walk through as long as indexes exist in both
+        for idx in range(min(num_orig, num_new)):
+            # TODO: py3.10 allows isinstance with Unions
+            yield from walk_find_diff(
+                orig_item=orig_item[idx],
+                new_item=new_item[idx],
+                curr_path=curr_path + [("__list__", idx)]
+            )
+
+        # when list sizes don't match, items are either added or removed
+        if num_orig > num_new:
+            for idx in range(num_new, num_orig):
+                yield DiffItem(
+                    original_value=orig_item[idx],
+                    new_value=None,
+                    path=curr_path + [("__list__", idx)],
+                )
+        elif num_orig < num_new:
+            for idx in range(num_orig, num_new):
+                yield DiffItem(
+                    original_value=None,
+                    new_value=new_item[idx],
+                    path=curr_path + [("__list__", num_orig + idx + 1)],
+                )
+
+    elif isinstance(orig_item, set):
+        for new_member in new_item - orig_item:
+            yield DiffItem(
+                original_value=None,
+                new_value=new_member,
+                path=curr_path + [("__set__", new_member)],
+            )
+        for missing_member in orig_item - new_item:
+            yield DiffItem(
+                original_value=missing_member,
+                new_value=None,
+                path=curr_path + [("__set__", missing_member)],
+            )
+
+    # simple equality covers enums
+    elif orig_item != new_item:
+        yield DiffItem(
+            original_value=orig_item,
+            new_value=new_item,
+            path=curr_path,
+        )

--- a/superscore/tests/test_compare.py
+++ b/superscore/tests/test_compare.py
@@ -9,7 +9,7 @@ from superscore.client import Client
 from superscore.compare import (AttributePath, DiffItem, EntryDiff,
                                 walk_find_diff)
 from superscore.model import (Collection, Entry, Parameter, Readback, Setpoint,
-                              Severity, Status)
+                              Severity, Snapshot, Status)
 
 
 def simplify_path(path: AttributePath) -> AttributePath:
@@ -120,7 +120,16 @@ date_format = "%Y-%m-%dT"
         "ffd668d3-57d9-404e-8366-0778af7aee61",
         []
     ),
-    (  # Same snapshot, no differences
+    (  # different initial type
+        "ffd668d3-57d9-404e-8366-0778af7aee61",
+        "8e380e15-5489-41db-a8a7-bc47a731f099",
+        [DiffItem(
+            path=[],
+            original_value=Snapshot,
+            new_value=Readback
+        )]
+    ),
+    (  # two different readbacks
         "ecb42cdb-b703-4562-86e1-45bd67a2ab1a",
         "8e380e15-5489-41db-a8a7-bc47a731f099",
         [
@@ -160,5 +169,9 @@ def test_client_diff(
     print(diff)
     assert len(expected_diffs) == len(diff.diffs)
     for found_diff, expected_diff in zip(diff.diffs, expected_diffs):
-        assert found_diff.original_value == expected_diff.original_value
-        assert found_diff.new_value == expected_diff.new_value
+        if isinstance(found_diff.original_value, Entry):
+            assert type(found_diff.original_value) == expected_diff.original_value
+            assert type(found_diff.new_value) == expected_diff.new_value
+        else:
+            assert found_diff.original_value == expected_diff.original_value
+            assert found_diff.new_value == expected_diff.new_value

--- a/superscore/tests/test_compare.py
+++ b/superscore/tests/test_compare.py
@@ -1,0 +1,164 @@
+from datetime import datetime
+from typing import List
+from uuid import UUID
+
+import pytest
+
+from superscore.backends.core import SearchTerm
+from superscore.client import Client
+from superscore.compare import (AttributePath, DiffItem, EntryDiff,
+                                walk_find_diff)
+from superscore.model import (Collection, Entry, Parameter, Readback, Setpoint,
+                              Severity, Status)
+
+
+def simplify_path(path: AttributePath) -> AttributePath:
+    """swap objects for their type, for ease of testing"""
+    simplified_path = []
+    for seg in path:
+        if isinstance(seg[0], Entry):
+            item = type(seg[0])
+        else:
+            item = seg[0]
+
+        if isinstance(seg[1], Entry):
+            val = type(seg[1])
+        else:
+            val = seg[1]
+
+        simplified_path.append((item, val))
+
+    return simplified_path
+
+
+def simplify_diff(diff: DiffItem) -> DiffItem:
+    if isinstance(diff.original_value, Entry):
+        orig_val = type(diff.original_value)
+    else:
+        orig_val = diff.original_value
+
+    if isinstance(diff.new_value, Entry):
+        new_val = type(diff.new_value)
+    else:
+        new_val = diff.new_value
+
+    return DiffItem(original_value=orig_val, new_value=new_val,
+                    path=simplify_path(diff.path))
+
+
+@pytest.mark.parametrize("orig,new,expected_diffs,", [
+    (Parameter(), Parameter(), []),
+    (Parameter(pv_name="orig"), Parameter(), [
+        DiffItem(
+            path=[(Parameter, "pv_name")], original_value="orig", new_value=""
+        ),
+    ]),
+    (Parameter(pv_name=""), Parameter(pv_name="new"), [
+        DiffItem(
+            path=[(Parameter, "pv_name")], original_value="", new_value="new"
+        ),
+    ]),
+    (Parameter(), Readback(), [
+        DiffItem(path=[], original_value=Parameter, new_value=Readback)
+    ]),
+    (Setpoint(severity=Severity.MAJOR), Setpoint(status=Status.HIGH), [
+        DiffItem(path=[(Setpoint, "status")],
+                 original_value=Status.UDF, new_value=Status.HIGH),
+        DiffItem(path=[(Setpoint, "severity")],
+                 original_value=Severity.MAJOR, new_value=Severity.INVALID)
+    ]),
+    (Collection(tags=set(["z", "c"])), Collection(tags=set(["a", "b", "z"])), [
+        DiffItem(path=[(Collection, "tags"), ("__set__", "a")],
+                 original_value=None, new_value="a"),
+        DiffItem(path=[(Collection, "tags"), ("__set__", "b")],
+                 original_value=None, new_value="b"),
+        DiffItem(path=[(Collection, "tags"), ("__set__", "c")],
+                 original_value="c", new_value=None),
+    ]),
+    (Collection(children=[]), Collection(children=[Parameter()]), [
+        DiffItem(path=[(Collection, "children"), ("__list__", 1)],
+                 original_value=None, new_value=Parameter),
+    ]),
+    (Collection(children=[Readback(), Readback()]), Collection(children=[Parameter()]), [
+        DiffItem(path=[(Collection, "children"), ("__list__", 0)],
+                 original_value=Readback, new_value=Parameter),
+        DiffItem(path=[(Collection, "children"), ("__list__", 1)],
+                 original_value=Readback, new_value=None),
+    ]),
+])
+def test_basic_diff(orig: Entry, new: Entry, expected_diffs: List[DiffItem]):
+    """
+    Compare expected paths to discovered.
+    Also verifies values in a simplified form (type of Entry's)
+    """
+    raw_found_diff = walk_find_diff(orig, new)
+
+    found_diff = [simplify_diff(diff) for diff in raw_found_diff
+                  if not isinstance(diff.original_value, (UUID, datetime))]
+    assert len(found_diff) == len(expected_diffs)
+
+    # Note: sets make no guarantees about order, so we have to check all diffs
+    # We could make some cross mapping, but iterating is simpler and I don't
+    # care to optimize for performance here (can't index on unhashable list)
+    for f_diff in found_diff:
+        match_found = False
+        for e_diff in expected_diffs:
+            if f_diff.path == e_diff.path:
+                match_found = True
+                assert f_diff.original_value == e_diff.original_value
+                assert f_diff.new_value == e_diff.new_value
+        assert match_found, "Matching path not found in expected paths"
+        print(f_diff)
+
+
+date_format = "%Y-%m-%dT"
+
+
+@pytest.mark.parametrize("l_uuid,r_uuid,expected_diffs,", [
+    (  # Same snapshot, no differences
+        "ffd668d3-57d9-404e-8366-0778af7aee61",
+        "ffd668d3-57d9-404e-8366-0778af7aee61",
+        []
+    ),
+    (  # Same snapshot, no differences
+        "ecb42cdb-b703-4562-86e1-45bd67a2ab1a",
+        "8e380e15-5489-41db-a8a7-bc47a731f099",
+        [
+            DiffItem(
+                path=[],
+                original_value=UUID("ecb42cdb-b703-4562-86e1-45bd67a2ab1a"),
+                new_value=UUID("8e380e15-5489-41db-a8a7-bc47a731f099"),
+            ),
+            DiffItem(
+                path=[],
+                original_value=datetime.fromisoformat("2024-05-10T16:49:34.574951+00:00"),
+                new_value=datetime.fromisoformat("2024-05-10T16:49:34.574987+00:00"),
+            ),
+            DiffItem(
+                path=[],
+                original_value="MY:PREFIX:mtr1.ACCL",
+                new_value="MY:PREFIX:mtr1.VELO",
+            ),
+
+        ]
+    ),
+])
+def test_client_diff(
+    sample_client: Client,
+    l_uuid: str,
+    r_uuid: str,
+    expected_diffs: list[DiffItem]
+):
+    """Run comparison tests based on filestore backend.  Ignore paths"""
+    l_entry = list(sample_client.search(
+        SearchTerm(operator='eq', attr='uuid', value=UUID(l_uuid))
+    ))[0]
+    r_entry = list(sample_client.search(
+        SearchTerm(operator='eq', attr='uuid', value=UUID(r_uuid))
+    ))[0]
+    diff: EntryDiff = sample_client.compare(l_entry, r_entry)
+    print(diff)
+    assert len(expected_diffs) == len(diff.diffs)
+    for found_diff, expected_diff in zip(diff.diffs, expected_diffs):
+        assert found_diff.original_value == expected_diff.original_value
+        assert found_diff.new_value == expected_diff.new_value


### PR DESCRIPTION
## Description
- Adds `EntryDiff`, which tracks two `Entry`s, along with a list of `DiffItem` objects
  - attempts to build reasonable reprs for the above as well (WIP)
- implements `Client.compare` using the above

## Motivation and Context
closes #9 

## How Has This Been Tested?
Tests added.  

## Where Has This Been Documented?
This PR, #9 

Example repr:
```
> client.compare( readback1, readback2 )
Diff: {
    Readback.uuid: (ecb42cdb-b703-4562-86e1-45bd67a2ab1a->8e380e15-5489-41db-a8a7-bc47a731f099)
    Readback.creation_time: (2024-05-10 16:49:34.574951+00:00->2024-05-10 16:49:34.574987+00:00)
    Readback.pv_name: (MY:PREFIX:mtr1.ACCL->MY:PREFIX:mtr1.VELO)
}
```

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
