### PR TITLE
TST: parametrize the filestore_backend fixture

### DIFF
--- a/docs/source/upcoming_release_notes/104-parametrize_filestore_backend_fixture.rst
+++ b/docs/source/upcoming_release_notes/104-parametrize_filestore_backend_fixture.rst
@@ -1,0 +1,25 @@
+104 parametrize filestore backend fixture
+#################
+
+API Breaks
+----------
+- the filestore_backend fixture requires parametrization using 'db/filestore.json' to match prior behaviour
+- the linac_data fixture returns a Root rather than a tuple of Entries
+- the comparison_linac_snapshot fixture has been renamed, and returns a Root containing the entries from linac_data in addition to its comparison snapshot
+
+Features
+--------
+- make the filestore_backend fixture accept pytest parametrized args
+- args can be a file path, functions that return a Root or Iterable[Entry], or function names resolvable in conftest.py
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- shilorigins

--- a/superscore/tests/conftest.py
+++ b/superscore/tests/conftest.py
@@ -839,12 +839,17 @@ def simple_snapshot() -> Collection:
 
 
 @pytest.fixture(scope='function')
-def filestore_backend(tmp_path: Path) -> FilestoreBackend:
-    fp = Path(__file__).parent / 'db' / 'filestore.json'
+def filestore_backend(request, tmp_path: Path) -> FilestoreBackend:
     tmp_fp = tmp_path / 'tmp_filestore.json'
-    shutil.copy(fp, tmp_fp)
+    try:
+        user_path = Path(request.param)
+        fp = user_path if user_path.is_absolute() else Path(__file__).parent / user_path
+        shutil.copy(fp, tmp_fp)
+    except (AttributeError, TypeError):
+        pass
+    backend = FilestoreBackend(path=tmp_fp)
     print(tmp_path)
-    return FilestoreBackend(path=tmp_fp)
+    return backend
 
 
 @pytest.fixture(scope='function')

--- a/superscore/tests/conftest.py
+++ b/superscore/tests/conftest.py
@@ -865,6 +865,29 @@ def populate_backend(backend, sources: Iterable[Union[Callable, str, Root, Entry
 
 @pytest.fixture(scope='function')
 def filestore_backend(request, tmp_path: Path) -> FilestoreBackend:
+    """
+    This fixture is intended to be given data via pytest.mark.parametrize in each test
+    definition that invokes it.  It can be parametrized even if a test doesn't invoke it
+    directly, such as if a test invokes a client fixture that then invokes it.  Invoking this
+    fixture without any parametrization results in a functional but empty backend.
+
+    Parametrization in intermediate fixture definitions will be clobbered by test
+    parametrization, so parametrizaton should only be done in test definitions to maintain
+    clarity around which data is being used.
+
+    Each parameter should be either:
+    - a path to a valid filestore, absolute or relative to conftest.py
+    - an Iterable of sources accepted by conftest.py::populate_backend
+
+    e.g.
+    @pytest.mark.parametrize("filestore_backend", ["db/filestore.json"], indirect=True)
+    def my_test(filestore_backend):
+        ...
+
+    @pytest.mark.parametrize("filestore_backend", [("linac_data",)], indirect=True)
+    def my_test(sample_client):
+        ...
+    """
     tmp_fp = tmp_path / 'tmp_filestore.json'
     try:
         source = request.param

--- a/superscore/tests/conftest.py
+++ b/superscore/tests/conftest.py
@@ -849,20 +849,18 @@ def populate_backend(backend, sources: Iterable[Union[Callable, str, Root, Entry
     """
     namespace = globals()
     for source in sources:
-        try:
+        if isinstance(source, Callable):
             data = source()
-        except TypeError:
-            try:
-                func = namespace[source]
-                data = func()
-            except (AttributeError, TypeError):
-                data = source
-        finally:
-            if isinstance(data, Root):
-                for entry in data.entries:
-                    backend.save_entry(entry)
-            else:
-                backend.save_entry(data)
+        elif source in namespace:
+            func = namespace[source]
+            data = func()
+        else:
+            data = source
+        if isinstance(data, Root):
+            for entry in data.entries:
+                backend.save_entry(entry)
+        else:
+            backend.save_entry(data)
 
 
 @pytest.fixture(scope='function')

--- a/superscore/tests/demo.cfg
+++ b/superscore/tests/demo.cfg
@@ -7,4 +7,4 @@ ca = true
 pva = true
 
 [demo]
-fixtures = linac_data comparison_linac_snapshot
+fixtures = linac_with_comparison_snapshot

--- a/superscore/tests/ioc/linac.py
+++ b/superscore/tests/ioc/linac.py
@@ -4,7 +4,7 @@ from superscore.tests.conftest import linac_data
 from superscore.tests.ioc import IOCFactory
 
 if __name__ == '__main__':
-    _, snapshot = linac_data()
+    _, snapshot = linac_data().entries
     LinacIOC = IOCFactory.from_entries(snapshot.children)
 
     ioc_options, run_options = ioc_arg_parser(

--- a/superscore/tests/test_backend.py
+++ b/superscore/tests/test_backend.py
@@ -50,6 +50,7 @@ class TestTestBackend:
 
 
 @pytest.mark.parametrize('backends', [0], indirect=True)
+@pytest.mark.parametrize("filestore_backend", ["db/filestore.json"], indirect=True)
 def test_save_entry(backends: _Backend):
     new_entry = Parameter()
 
@@ -63,6 +64,7 @@ def test_save_entry(backends: _Backend):
 
 
 @pytest.mark.parametrize('backends', [0], indirect=True)
+@pytest.mark.parametrize("filestore_backend", ["db/filestore.json"], indirect=True)
 def test_delete_entry(backends: _Backend):
     entry = backends.root.entries[0]
     backends.delete_entry(entry)
@@ -71,6 +73,7 @@ def test_delete_entry(backends: _Backend):
 
 
 @pytest.mark.parametrize('backends', [0], indirect=True)
+@pytest.mark.parametrize("filestore_backend", ["db/filestore.json"], indirect=True)
 def test_search_entry(backends: _Backend):
     # Given an entry we know is in the backend
     results = backends.search(
@@ -116,6 +119,7 @@ def test_search_entry(backends: _Backend):
 
 
 @pytest.mark.parametrize('backends', [0], indirect=True)
+@pytest.mark.parametrize("filestore_backend", ["db/filestore.json"], indirect=True)
 def test_fuzzy_search(backends: _Backend):
     results = list(backends.search(
         SearchTerm('description', 'like', 'motor'))
@@ -134,6 +138,7 @@ def test_fuzzy_search(backends: _Backend):
 
 
 @pytest.mark.parametrize('backends', [0], indirect=True)
+@pytest.mark.parametrize("filestore_backend", ["db/filestore.json"], indirect=True)
 def test_tag_search(backends: _Backend):
     results = list(backends.search(
         SearchTerm('tags', 'gt', set())
@@ -161,6 +166,7 @@ def test_tag_search(backends: _Backend):
 
 
 @pytest.mark.parametrize('backends', [0], indirect=True)
+@pytest.mark.parametrize("filestore_backend", ["db/filestore.json"], indirect=True)
 def test_search_error(backends: _Backend):
     with pytest.raises(TypeError):
         results = backends.search(
@@ -175,6 +181,7 @@ def test_search_error(backends: _Backend):
 
 
 @pytest.mark.parametrize('backends', [0], indirect=True)
+@pytest.mark.parametrize("filestore_backend", ["db/filestore.json"], indirect=True)
 def test_update_entry(backends: _Backend):
     # grab an entry from the database and modify it.
     entry = list(backends.search(

--- a/superscore/tests/test_client.py
+++ b/superscore/tests/test_client.py
@@ -141,6 +141,7 @@ def test_find_config(sscore_cfg: str):
     assert 'other/cfg' == Client.find_config()
 
 
+@pytest.mark.parametrize("filestore_backend", ["db/filestore.json"], indirect=True)
 def test_search(sample_client):
     results = list(sample_client.search(
         ('data', 'isclose', (4, 0, 0))
@@ -170,6 +171,7 @@ def uuids_in_entry(entry: Entry):
     "a9f289d4-3421-4107-8e7f-2fe0daab77a5",
     "ffd668d3-57d9-404e-8366-0778af7aee61",
 ])
+@pytest.mark.parametrize("filestore_backend", ["db/filestore.json"], indirect=True)
 def test_fill(sample_client: Client, entry_uuid: str):
     entry = list(sample_client.search(
         ("uuid", "eq", UUID(entry_uuid))

--- a/superscore/tests/test_client.py
+++ b/superscore/tests/test_client.py
@@ -208,3 +208,12 @@ def test_fill_depth(fill_depth: int):
     client.fill(deep_coll, fill_depth)
 
     assert nest_depth(deep_coll) == fill_depth
+
+
+@pytest.mark.parametrize("filestore_backend", [("linac_with_comparison_snapshot",)], indirect=True)
+def test_parametrized_filestore(sample_client: Client):
+    assert len(list(sample_client.search())) > 0
+
+
+def test_parametrized_filestore_empty(sample_client: Client):
+    assert len(list(sample_client.search())) == 0

--- a/superscore/tests/test_compare.py
+++ b/superscore/tests/test_compare.py
@@ -152,6 +152,7 @@ date_format = "%Y-%m-%dT"
         ]
     ),
 ])
+@pytest.mark.parametrize("filestore_backend", ["db/filestore.json"], indirect=True)
 def test_client_diff(
     sample_client: Client,
     l_uuid: str,

--- a/superscore/tests/test_page.py
+++ b/superscore/tests/test_page.py
@@ -108,6 +108,7 @@ def test_page_smoke(page: str, request: pytest.FixtureRequest):
     print(type(request.getfixturevalue(page)))
 
 
+@pytest.mark.parametrize("filestore_backend", ["db/filestore.json"], indirect=True)
 def test_apply_filter(search_page: SearchPage):
     search_page.apply_filter_button.clicked.emit()
     assert search_page.results_table_view.model().rowCount() == 6
@@ -135,6 +136,7 @@ def test_apply_filter(search_page: SearchPage):
     assert search_page.results_table_view.model().rowCount() == 1
 
 
+@pytest.mark.parametrize("filestore_backend", ["db/filestore.json"], indirect=True)
 def test_coll_builder_add(collection_builder_page: CollectionBuilderPage):
     page = collection_builder_page
 
@@ -153,6 +155,7 @@ def test_coll_builder_add(collection_builder_page: CollectionBuilderPage):
     assert page.sub_coll_table_view._model.rowCount() == 1
 
 
+@pytest.mark.parametrize("filestore_backend", ["db/filestore.json"], indirect=True)
 def test_coll_builder_edit(
     collection_builder_page: CollectionBuilderPage,
     qtbot: QtBot

--- a/superscore/tests/test_window.py
+++ b/superscore/tests/test_window.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 
+import pytest
 from pytestqt.qtbot import QtBot
 
 from superscore.client import Client
@@ -22,6 +23,7 @@ def test_main_window(qtbot: QtBot, mock_client: Client):
     qtbot.addWidget(window)
 
 
+@pytest.mark.parametrize("filestore_backend", ["db/filestore.json"], indirect=True)
 def test_sample_window(qtbot: QtBot, sample_client: Client):
     window = Window(client=sample_client)
     qtbot.addWidget(window)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Refactor the `filestore_backend` fixture to accept parametrized args.  Each arg can be a path to a file or an iterable of functions or function names.  Function names must be accessible from the `conftest.py` namespace.  Functions must return a `Root` or an iterable of `Entry`s. 

Closes #103 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Parametrizing `filestore_backend` enables us to choose what data to use in a test without having to define a dedicated fixture.  Parametrization also allows us to easily run the same test on multiple data sources.

Supporting function names in the `conftest.py` namespace let's us select widely used data sources defined in `conftest.py` without having to import the functions.  Supporting function literals additionally let's us define more narrowly used data sources in test files and pass those into the backend. 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests were adjusted to specify the same data they were using before.  I also added a test that uses function names as the parameter; this test will be replaced in an upcoming PR.
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
