### PR TITLE
BUG: fix tree fill behavior

### DIFF
--- a/docs/source/upcoming_release_notes/105-bug_tree_fill.rst
+++ b/docs/source/upcoming_release_notes/105-bug_tree_fill.rst
@@ -16,6 +16,8 @@ Bugfixes
 Maintenance
 -----------
 - Adjust `Client.fill` to allow us to specify fill depth
+- Move `FilestoreBackend.compare` upstream into `_Backend`
+- Implement `.search` and `.root` in `TestBackend` for completeness
 
 Contributors
 ------------

--- a/docs/source/upcoming_release_notes/105-bug_tree_fill.rst
+++ b/docs/source/upcoming_release_notes/105-bug_tree_fill.rst
@@ -1,0 +1,22 @@
+105 bug_tree_fill
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Properly fill items in the the shared tree view (`RootTree`)
+
+Maintenance
+-----------
+- Adjust `Client.fill` to allow us to specify fill depth
+
+Contributors
+------------
+- tangkong

--- a/superscore/backends/core.py
+++ b/superscore/backends/core.py
@@ -1,6 +1,7 @@
 """
 Base superscore data storage backend interface
 """
+import re
 from collections.abc import Container, Generator
 from typing import NamedTuple, Union
 from uuid import UUID
@@ -65,6 +66,41 @@ class _Backend:
         - like (fuzzy match, depends on type of value)
         """
         raise NotImplementedError
+
+    @staticmethod
+    def compare(op: str, data: AnyEpicsType, target: SearchTermValue) -> bool:
+        """
+        Return whether data and target satisfy the op comparator, typically durihg application
+        of a search filter. Possible values of op are detailed in _Backend.search
+
+        Parameters
+        ----------
+        op: str
+            one of the comparators that all backends must support, detailed in _Backend.search
+        data: AnyEpicsType | Tuple[AnyEpicsType]
+            data from an Entry that is being used to decide whether the Entry passes a filter
+        target: AnyEpicsType | Tuple[AnyEpicsType]
+            the filter value
+
+        Returns
+        -------
+        bool
+            whether data and target satisfy the op condition
+        """
+        if op == "eq":
+            return data == target
+        elif op == "lt":
+            return data <= target
+        elif op == "gt":
+            return data >= target
+        elif op == "in":
+            return data in target
+        elif op == "like":
+            if isinstance(data, UUID):
+                data = str(data)
+            return re.search(target, data)
+        else:
+            raise ValueError(f"SearchTerm does not support operator \"{op}\"")
 
     @property
     def root(self) -> Root:

--- a/superscore/backends/core.py
+++ b/superscore/backends/core.py
@@ -70,7 +70,7 @@ class _Backend:
     @staticmethod
     def compare(op: str, data: AnyEpicsType, target: SearchTermValue) -> bool:
         """
-        Return whether data and target satisfy the op comparator, typically durihg application
+        Return whether data and target satisfy the op comparator, typically during application
         of a search filter. Possible values of op are detailed in _Backend.search
 
         Parameters

--- a/superscore/backends/filestore.py
+++ b/superscore/backends/filestore.py
@@ -6,7 +6,6 @@ import contextlib
 import json
 import logging
 import os
-import re
 import shutil
 from dataclasses import fields, replace
 from typing import Any, Dict, Generator, Optional, Union
@@ -14,10 +13,9 @@ from uuid import UUID, uuid4
 
 from apischema import deserialize, serialize
 
-from superscore.backends.core import SearchTermType, SearchTermValue, _Backend
+from superscore.backends.core import SearchTermType, _Backend
 from superscore.errors import BackendError
 from superscore.model import Entry, Root
-from superscore.type_hints import AnyEpicsType
 from superscore.utils import build_abs_path
 
 logger = logging.getLogger(__name__)
@@ -303,41 +301,6 @@ class FilestoreBackend(_Backend):
                             conditions.append(False)
                 if all(conditions):
                     yield entry
-
-    @staticmethod
-    def compare(op: str, data: AnyEpicsType, target: SearchTermValue) -> bool:
-        """
-        Return whether data and target satisfy the op comparator, typically durihg application
-        of a search filter. Possible values of op are detailed in _Backend.search
-
-        Parameters
-        ----------
-        op: str
-            one of the comparators that all backends must support, detailed in _Backend.search
-        data: AnyEpicsType | Tuple[AnyEpicsType]
-            data from an Entry that is being used to decide whether the Entry passes a filter
-        target: AnyEpicsType | Tuple[AnyEpicsType]
-            the filter value
-
-        Returns
-        -------
-        bool
-            whether data and target satisfy the op condition
-        """
-        if op == "eq":
-            return data == target
-        elif op == "lt":
-            return data <= target
-        elif op == "gt":
-            return data >= target
-        elif op == "in":
-            return data in target
-        elif op == "like":
-            if isinstance(data, UUID):
-                data = str(data)
-            return re.search(target, data)
-        else:
-            raise ValueError(f"SearchTerm does not support operator \"{op}\"")
 
     @contextlib.contextmanager
     def _load_and_store_context(self) -> Generator[Dict[UUID, Any], None, None]:

--- a/superscore/backends/test.py
+++ b/superscore/backends/test.py
@@ -1,10 +1,11 @@
 """
 Backend that manipulates Entries in-memory for testing purposes.
 """
-from typing import List, Optional, Union
+from copy import deepcopy
+from typing import Dict, List, Optional, Union
 from uuid import UUID
 
-from superscore.backends.core import _Backend
+from superscore.backends.core import SearchTermType, _Backend
 from superscore.errors import (BackendError, EntryExistsError,
                                EntryNotFoundError)
 from superscore.model import Entry, Nestable, Root
@@ -12,6 +13,8 @@ from superscore.model import Entry, Nestable, Root
 
 class TestBackend(_Backend):
     """Backend that manipulates Entries in-memory, for testing purposes."""
+    _entry_cache: Dict[UUID, Entry] = {}
+
     def __init__(self, data: Optional[List[Entry]] = None):
         if data is None:
             self.data = []
@@ -19,6 +22,19 @@ class TestBackend(_Backend):
             self.data = data
 
         self._root = Root(entries=self.data)
+        self._fill_entry_cache()
+
+    def _fill_entry_cache(self) -> None:
+        self._entry_cache = {}
+        stack = deepcopy(self.data)
+        while len(stack) > 0:
+            entry = stack.pop()
+            uuid = entry.uuid
+            if isinstance(uuid, str):
+                uuid = UUID(uuid)
+            self._entry_cache[uuid] = entry
+            if isinstance(entry, Nestable):
+                stack.extend(entry.children)
 
     def save_entry(self, entry: Entry) -> None:
         try:
@@ -26,18 +42,16 @@ class TestBackend(_Backend):
             raise EntryExistsError(f"Entry {entry.uuid} already exists")
         except EntryNotFoundError:
             self.data.append(entry)
+            self._fill_entry_cache()
 
     def get_entry(self, uuid: Union[UUID, str]) -> Entry:
         if isinstance(uuid, str):
             uuid = UUID(uuid)
-        stack = self.data.copy()
-        while len(stack) > 0:
-            entry = stack.pop()
-            if entry.uuid == uuid:
-                return entry
-            if isinstance(entry, Nestable):
-                stack.extend(entry.children)
-        raise EntryNotFoundError(f"Entry {entry.uuid} could not be found")
+
+        try:
+            return self._entry_cache[uuid]
+        except KeyError:
+            raise EntryNotFoundError(f"Entry {uuid} could not be found")
 
     def update_entry(self, entry: Entry) -> None:
         original = self.get_entry(entry.uuid)
@@ -54,6 +68,25 @@ class TestBackend(_Backend):
                     raise BackendError(f"Can't delete: entry {to_delete.uuid} is out of sync with the version in the backend")
             stack.extend([entry.children for entry in children if isinstance(entry, Nestable)])
 
+        self._fill_entry_cache()
+
     @property
     def root(self) -> Root:
         return self._root
+
+    def search(self, *search_terms: SearchTermType):
+        for entry in self._entry_cache.values():
+            conditions = []
+            for attr, op, target in search_terms:
+                # TODO: search for child pvs?
+                if attr == "entry_type":
+                    conditions.append(isinstance(entry, target))
+                else:
+                    try:
+                        # check entry attribute by name
+                        value = getattr(entry, attr)
+                        conditions.append(self.compare(op, value, target))
+                    except AttributeError:
+                        conditions.append(False)
+            if all(conditions):
+                yield entry

--- a/superscore/backends/test.py
+++ b/superscore/backends/test.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from superscore.backends.core import _Backend
 from superscore.errors import (BackendError, EntryExistsError,
                                EntryNotFoundError)
-from superscore.model import Entry, Nestable
+from superscore.model import Entry, Nestable, Root
 
 
 class TestBackend(_Backend):
@@ -17,6 +17,8 @@ class TestBackend(_Backend):
             self.data = []
         else:
             self.data = data
+
+        self._root = Root(entries=self.data)
 
     def save_entry(self, entry: Entry) -> None:
         try:
@@ -51,3 +53,7 @@ class TestBackend(_Backend):
                 elif entry.uuid == to_delete.uuid:
                     raise BackendError(f"Can't delete: entry {to_delete.uuid} is out of sync with the version in the backend")
             stack.extend([entry.children for entry in children if isinstance(entry, Nestable)])
+
+    @property
+    def root(self) -> Root:
+        return self._root

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -231,10 +231,9 @@ class Client:
             If None, fill until there is no filling left
         """
         if fill_depth is not None:
-            if fill_depth < 0:
-                return
-
             fill_depth -= 1
+            if fill_depth <= 0:
+                return
 
         if isinstance(entry, Nestable):
             new_children = []

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -219,12 +219,12 @@ class Client:
     def fill(self, entry: Union[Entry, UUID], fill_depth: Optional[int] = None) -> None:
         """
         Walk through ``entry`` and replace UUIDs with corresponding Entry's.
-        Currently only has meaning for Nestables.  Filling happens "in-place",
-        modifying ``entry``.
+        Does nothing if ``entry`` is a non-Nestable or UUID.
+        Filling happens "in-place", modifying ``entry``.
 
         Parameters
         ----------
-        entry : Entry
+        entry : Union[Entry, UUID]
             Entry that may contain UUIDs to be filled with full Entry's
         fill_depth : Optional[int], by default None
             The depth to fill.  (value of 1 will fill just ``entry``'s children)

--- a/superscore/tests/test_client.py
+++ b/superscore/tests/test_client.py
@@ -195,7 +195,7 @@ def test_fill_depth(fill_depth: int):
     bknd = TestBackend([deep_coll])
     client = Client(backend=bknd)
 
-    assert nest_depth(deep_coll) == 40
+    assert nest_depth(deep_coll) == 20
     deep_coll.swap_to_uuids()
     # for this test we want everything to be UUIDS
     for entry in bknd._entry_cache.values():

--- a/superscore/tests/test_client.py
+++ b/superscore/tests/test_client.py
@@ -7,13 +7,13 @@ import pytest
 
 from superscore.backends.core import SearchTerm
 from superscore.backends.filestore import FilestoreBackend
+from superscore.backends.test import TestBackend
 from superscore.client import Client
 from superscore.control_layers import EpicsData
 from superscore.errors import CommunicationError
 from superscore.model import (Collection, Entry, Nestable, Parameter, Readback,
                               Root, Setpoint)
-
-from .conftest import MockTaskStatus
+from superscore.tests.conftest import MockTaskStatus, nest_depth
 
 SAMPLE_CFG = Path(__file__).parent / 'config.cfg'
 
@@ -181,3 +181,28 @@ def test_fill(sample_client: Client, entry_uuid: str):
 
     sample_client.fill(entry)
     assert not uuids_in_entry(entry)
+
+
+@pytest.mark.parametrize("fill_depth,", list(range(1, 11)))
+def test_fill_depth(fill_depth: int):
+    deep_coll = Collection()
+    prev_coll = deep_coll
+    # Be sure more depth exists than the requested depth
+    for i in range(20):
+        child_coll = Collection(title=f"collection {i}")
+        prev_coll.children.append(child_coll)
+        prev_coll = child_coll
+    bknd = TestBackend([deep_coll])
+    client = Client(backend=bknd)
+
+    assert nest_depth(deep_coll) == 40
+    deep_coll.swap_to_uuids()
+    # for this test we want everything to be UUIDS
+    for entry in bknd._entry_cache.values():
+        entry.swap_to_uuids()
+
+    assert nest_depth(deep_coll) == 1
+
+    client.fill(deep_coll, fill_depth)
+
+    assert nest_depth(deep_coll) == fill_depth

--- a/superscore/tests/test_views.py
+++ b/superscore/tests/test_views.py
@@ -234,7 +234,7 @@ def test_fill_uuids_nestable(
     assert all(not isinstance(c, UUID) for c in nested_coll.children)
 
 
-def test_fill_uuids_entry_item(linac_backend: TestBackend):
+def test_fill_uuids_entry_item(linac_backend: TestBackend, qtbot: QtBot):
     client = Client(backend=linac_backend)
     nested_coll = linac_backend.get_entry("441ff79f-4948-480e-9646-55a1462a5a70")
     assert not all(isinstance(c, UUID) for c in nested_coll.children)
@@ -247,6 +247,19 @@ def test_fill_uuids_entry_item(linac_backend: TestBackend):
     original_depth = nest_depth(tree_model.root_item)
     assert original_depth == 1
 
-    tree_model.root_item.fill_uuids(client)
-    new_depth = nest_depth(tree_model.root_item)
-    assert new_depth == 4
+    # fill just the first child
+    # fill depth can depend on how the backend returns data.  Backend may not
+    # be lazy, so we assert only child1's children have EntryItems
+    root_item = tree_model.root_item
+    child1 = root_item.child(0)
+    assert child1.childCount() == 0
+    child1.fill_uuids(client)
+    assert child1.childCount() > 0
+    assert root_item.child(1).childCount() == 0
+    assert root_item.child(2).childCount() == 0
+
+    # filling the root item fills its children, which held uuids before
+    root_item.fill_uuids(client)
+    assert root_item.child(0).childCount() > 0
+    assert root_item.child(1).childCount() > 0
+    assert root_item.child(2).childCount() > 0

--- a/superscore/tests/test_window.py
+++ b/superscore/tests/test_window.py
@@ -39,7 +39,9 @@ def test_sample_window(qtbot: QtBot, sample_client: Client):
 
     first_index = window.tree_view.model().index(0, 0)
     last_index = get_last_index(first_index)
+    # expand does not fetch more data by itself
     window.tree_view.expand(last_index)
+    window.tree_view.model().fetchMore(last_index)
 
     assert count_visible_items(window.tree_view) == 7
 

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -465,7 +465,7 @@ class RootTree(QtCore.QAbstractItemModel):
 
         return None
 
-    def canFetchMore(self, parent: QtCore.QModelIndex):
+    def canFetchMore(self, parent: QtCore.QModelIndex) -> bool:
         item: EntryItem = parent.internalPointer()
         if item is None:
             return False
@@ -478,7 +478,7 @@ class RootTree(QtCore.QAbstractItemModel):
 
         return False
 
-    def fetchMore(self, parent: QtCore.QModelIndex):
+    def fetchMore(self, parent: QtCore.QModelIndex) -> None:
         item: EntryItem = parent.internalPointer()
         item.fill_uuids(client=self.client)
 


### PR DESCRIPTION
## Description
- Make `RootTree` tree model fill uuids when expanding items.
- Adjust `Client.fill` to allow us to specify the fill extent.
- Do some maintenance on the backend classes
  - upstream `FilestoreBackend.compare` into `_Backend`
  - implement `.search()` in `TestBackend`

## Motivation and Context
fixes #100 
There was a lot of touching up to do here, hopefully I properly handled things.

### `fetchMore`
Half way into trying to gather all the signals that fire when an item is expanded, I realized there's a pair of "fetch" methods  qt provides us to handle lazy loading of data.  These are split into:
- `QAbstractItemModel.canFetchMore() -> bool`: where we set the logic to determine if data needs to be fetched
- `QAbstractItemModel.fetchMore()`: which actually fetches the data.

This actually ended up working quite smoothly, with most of my time being spent squishing bugs I made.

## How Has This Been Tested?
Interactively, and with unit tests.

I instrumented the function calls and made sure that entries were only filled when their parents were expanded.  I tried to add this to the tests as best I could (in progress)

Interactively, I've been able to expand the tree fully.

## Where Has This Been Documented?
In the linked issue and this PR

![image](https://github.com/user-attachments/assets/75ebca47-6a24-4de5-ab52-f4b6462689f2)

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
