### PR TITLE
MNT: move context menu functionality upstream into `RootTreeView`

### DIFF
--- a/docs/source/upcoming_release_notes/107-mnt_upstream_tree_view.rst
+++ b/docs/source/upcoming_release_notes/107-mnt_upstream_tree_view.rst
@@ -1,0 +1,22 @@
+107 mnt_upstream_tree_view
+##########################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Fills the top-level entry whenever RootTree model is created, to ensure at least first level of children display
+
+Maintenance
+-----------
+- Adds common RootTreeView which holds the RootTree model.  Upstreams standard settings and context menu support
+
+Contributors
+------------
+- tangkong

--- a/superscore/backends/test.py
+++ b/superscore/backends/test.py
@@ -13,6 +13,7 @@ from superscore.model import Entry, Nestable, Root
 
 class TestBackend(_Backend):
     """Backend that manipulates Entries in-memory, for testing purposes."""
+    __test__ = False  # Tell pytest this isn't a test case
     _entry_cache: Dict[UUID, Entry] = {}
 
     def __init__(self, data: Optional[List[Entry]] = None):

--- a/superscore/tests/test_views.py
+++ b/superscore/tests/test_views.py
@@ -242,24 +242,29 @@ def test_fill_uuids_entry_item(linac_backend: TestBackend, qtbot: QtBot):
     nested_coll.swap_to_uuids()
     assert all(isinstance(c, UUID) for c in nested_coll.children)
 
-    tree_model = RootTree(base_entry=nested_coll, client=client)
+    # hack: make all of linac_backend flat
+    for entry in linac_backend._entry_cache.values():
+        entry.swap_to_uuids()
 
+    tree_model = RootTree(base_entry=nested_coll, client=client)
     original_depth = nest_depth(tree_model.root_item)
-    assert original_depth == 1
+    # default fill depth is 2, so children and their children get EntryItems
+    assert original_depth == 2
 
     # fill just the first child
     # fill depth can depend on how the backend returns data.  Backend may not
     # be lazy, so we assert only child1's children have EntryItems
     root_item = tree_model.root_item
     child1 = root_item.child(0)
-    assert child1.childCount() == 0
+    assert child1.child(0).childCount() == 0
     child1.fill_uuids(client)
-    assert child1.childCount() > 0
-    assert root_item.child(1).childCount() == 0
-    assert root_item.child(2).childCount() == 0
+    assert child1.child(0).childCount() > 0
+    assert root_item.child(1).child(0).childCount() == 0
+    assert root_item.child(2).child(0).childCount() == 0
 
-    # filling the root item fills its children, which held uuids before
+    # filling only occurs if direct children are UUIDs, does nothing here
+    # since it was originally filled by RootTree
     root_item.fill_uuids(client)
-    assert root_item.child(0).childCount() > 0
-    assert root_item.child(1).childCount() > 0
-    assert root_item.child(2).childCount() > 0
+    assert root_item.child(0).child(0).childCount() > 0
+    assert root_item.child(1).child(0).childCount() == 0
+    assert root_item.child(2).child(0).childCount() == 0

--- a/superscore/tests/test_views.py
+++ b/superscore/tests/test_views.py
@@ -11,11 +11,12 @@ from qtpy import QtCore, QtWidgets
 from superscore.backends.test import TestBackend
 from superscore.client import Client
 from superscore.control_layers import EpicsData
-from superscore.model import Collection, Parameter, Severity, Status
+from superscore.model import Collection, Parameter, Root, Severity, Status
 from superscore.tests.conftest import nest_depth
-from superscore.widgets.views import (CustRoles, LivePVHeader,
+from superscore.widgets.views import (CustRoles, EntryItem, LivePVHeader,
                                       LivePVTableModel, LivePVTableView,
-                                      NestableTableView, RootTree)
+                                      NestableTableView, RootTree,
+                                      RootTreeView)
 
 
 @pytest.fixture(scope='function')
@@ -268,3 +269,29 @@ def test_fill_uuids_entry_item(linac_backend: TestBackend, qtbot: QtBot):
     assert root_item.child(0).child(0).childCount() > 0
     assert root_item.child(1).child(0).childCount() == 0
     assert root_item.child(2).child(0).childCount() == 0
+
+
+def test_roottree_setup(sample_database: Root):
+    tree_model = RootTree(base_entry=sample_database)
+    root_index = tree_model.index_from_item(tree_model.root_item)
+    # Check that the entire tree was created
+    assert tree_model.rowCount(root_index) == 4
+    assert tree_model.root_item.child(3).childCount() == 3
+
+
+def test_root_tree_view_setup_init_args(sample_client: Client):
+    tree_view = RootTreeView(
+        client=sample_client,
+        entry=sample_client.backend.root
+    )
+    assert isinstance(tree_view.model().root_item, EntryItem)
+    assert isinstance(tree_view.model(), RootTree)
+
+
+def test_root_tree_view_setup_post_init(sample_client: Client):
+    tree_view = RootTreeView()
+    tree_view.client = sample_client
+    tree_view.set_data(sample_client.backend.root)
+
+    assert isinstance(tree_view.model().root_item, EntryItem)
+    assert isinstance(tree_view.model(), RootTree)

--- a/superscore/tests/test_widgets.py
+++ b/superscore/tests/test_widgets.py
@@ -5,9 +5,8 @@ from uuid import uuid4
 import pytest
 from pytestqt.qtbot import QtBot
 
-from superscore.model import Collection, Root
+from superscore.model import Collection
 from superscore.widgets.core import DataWidget
-from superscore.widgets.views import RootTree
 
 
 @pytest.mark.parametrize(
@@ -39,11 +38,3 @@ def test_collection_datawidget_bridge(
 
     qtbot.addWidget(widget1)
     qtbot.addWidget(widget2)
-
-
-def test_roottree_setup(sample_database: Root):
-    tree_model = RootTree(base_entry=sample_database)
-    root_index = tree_model.index_from_item(tree_model.root_item)
-    # Check that the entire tree was created
-    assert tree_model.rowCount(root_index) == 4
-    assert tree_model.root_item.child(3).childCount() == 3

--- a/superscore/tests/test_window.py
+++ b/superscore/tests/test_window.py
@@ -16,9 +16,9 @@ def count_visible_items(tree_view):
     return count
 
 
-def test_main_window(qtbot: QtBot, mock_client: Client):
+def test_main_window(qtbot: QtBot, sample_client: Client):
     """Pass if main window opens successfully"""
-    window = Window(client=mock_client)
+    window = Window(client=sample_client)
     qtbot.addWidget(window)
 
 

--- a/superscore/ui/collection_builder_page.ui
+++ b/superscore/ui/collection_builder_page.ui
@@ -42,7 +42,7 @@
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-     <widget class="QTreeView" name="tree_view">
+     <widget class="RootTreeView" name="tree_view">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
         <horstretch>1</horstretch>
@@ -211,6 +211,11 @@
   <customwidget>
    <class>NestableTableView</class>
    <extends>QTableView</extends>
+   <header>superscore.widgets.views</header>
+  </customwidget>
+  <customwidget>
+   <class>RootTreeView</class>
+   <extends>QTreeView</extends>
    <header>superscore.widgets.views</header>
   </customwidget>
  </customwidgets>

--- a/superscore/ui/main_window.ui
+++ b/superscore/ui/main_window.ui
@@ -53,7 +53,7 @@
          </layout>
         </item>
         <item>
-         <widget class="QTreeView" name="tree_view">
+         <widget class="RootTreeView" name="tree_view">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
             <horstretch>0</horstretch>
@@ -85,7 +85,7 @@
      <x>0</x>
      <y>0</y>
      <width>800</width>
-     <height>37</height>
+     <height>20</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -177,6 +177,13 @@
    </property>
   </action>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>RootTreeView</class>
+   <extends>QTreeView</extends>
+   <header>superscore.widgets.views</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/superscore/ui/nestable_page.ui
+++ b/superscore/ui/nestable_page.ui
@@ -42,7 +42,7 @@
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-     <widget class="QTreeView" name="tree_view">
+     <widget class="RootTreeView" name="tree_view">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
         <horstretch>1</horstretch>
@@ -83,6 +83,11 @@
   <customwidget>
    <class>NestableTableView</class>
    <extends>QTableView</extends>
+   <header>superscore.widgets.views</header>
+  </customwidget>
+  <customwidget>
+   <class>RootTreeView</class>
+   <extends>QTreeView</extends>
    <header>superscore.widgets.views</header>
   </customwidget>
  </customwidgets>

--- a/superscore/widgets/page/collection_builder.py
+++ b/superscore/widgets/page/collection_builder.py
@@ -12,7 +12,7 @@ from superscore.widgets.enhanced import FilterComboBox
 from superscore.widgets.manip_helpers import insert_widget
 from superscore.widgets.views import (BaseTableEntryModel, LivePVHeader,
                                       LivePVTableView, NestableTableView,
-                                      RootTree)
+                                      RootTree, RootTreeView)
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ class CollectionBuilderPage(Display, DataWidget):
     meta_placeholder: QtWidgets.QWidget
     meta_widget: NameDescTagsWidget
 
-    tree_view: QtWidgets.QTreeView
+    tree_view: RootTreeView
 
     sub_coll_table_view: NestableTableView
     sub_pv_table_view: LivePVTableView
@@ -88,8 +88,11 @@ class CollectionBuilderPage(Display, DataWidget):
         self.sub_coll_table_view.client = self.client
         self.sub_coll_table_view.set_data(self.data)
 
-        self.tree_model = RootTree(base_entry=self.data, client=self.client)
-        self.tree_view.setModel(self.tree_model)
+        self.tree_view.client = self.client
+        self.tree_view.set_data(self.data)
+        self.tree_view.open_page_slot = self.open_page_slot
+        self.tree_model: RootTree = self.tree_view.model()
+
         self.sub_coll_table_view.data_updated.connect(self.tree_model.refresh_tree)
         self.sub_pv_table_view.data_updated.connect(self.tree_model.refresh_tree)
 

--- a/superscore/widgets/page/entry.py
+++ b/superscore/widgets/page/entry.py
@@ -19,7 +19,8 @@ from superscore.widgets.manip_helpers import (insert_widget,
                                               match_line_edit_text_width)
 from superscore.widgets.thread_helpers import BusyCursorThread
 from superscore.widgets.views import (LivePVTableView, NestableTableView,
-                                      RootTree, edit_widget_from_epics_data)
+                                      RootTreeView,
+                                      edit_widget_from_epics_data)
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +30,7 @@ class NestablePage(Display, DataWidget):
 
     meta_placeholder: QtWidgets.QWidget
     meta_widget: NameDescTagsWidget
-    tree_view: QtWidgets.QTreeView
+    tree_view: RootTreeView
     sub_coll_table_view: NestableTableView
     sub_pv_table_view: LivePVTableView
 
@@ -58,8 +59,9 @@ class NestablePage(Display, DataWidget):
         insert_widget(self.meta_widget, self.meta_placeholder)
 
         # show tree view
-        self.model = RootTree(base_entry=self.data, client=self.client)
-        self.tree_view.setModel(self.model)
+        self.tree_view.client = self.client
+        self.tree_view.set_data(self.data)
+        self.tree_view.open_page_slot = self.open_page_slot
 
         self.sub_pv_table_view.client = self.client
         self.sub_pv_table_view.set_data(self.data)

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -71,8 +71,15 @@ class EntryItem:
                 self._bridge_cache[id(data)] = bridge
                 self.bridge = bridge
 
-    def fill_uuids(self, client: Optional[Client] = None) -> None:
-        """Fill this item's data if it is a uuid, using ``client``"""
+    def fill_uuids(
+        self,
+        client: Optional[Client] = None,
+        fill_depth: int = 2
+    ) -> None:
+        """
+        Fill this item's data if it is a uuid, using ``client``.
+        By default fills to a depth of 2, to keep the tree view data loading lazy
+        """
         if client is None:
             return
 
@@ -82,7 +89,7 @@ class EntryItem:
 
         if isinstance(self._data, Nestable):
             if any(isinstance(child, UUID) for child in self._data.children):
-                client.fill(self._data, fill_depth=2)
+                client.fill(self._data, fill_depth=fill_depth)
 
             # re-construct child EntryItems if there is a mismatch or if any
             # hold UUIDs as _data
@@ -539,9 +546,6 @@ class RootTreeView(QtWidgets.QTreeView):
 
     @client.setter
     def client(self, client: Client):
-        self._set_client(client)
-
-    def _set_client(self, client: Client):
         if client is self._client:
             return
 

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -288,6 +288,8 @@ class RootTree(QtCore.QAbstractItemModel):
         self.base_entry = base_entry
         self.root_item = build_tree(base_entry)
         self.client = client
+        # ensure at least the first set of children are filled
+        self.root_item.fill_uuids(self.client)
         self.headers = ['name', 'description']
 
     def refresh_tree(self) -> None:

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import logging
 import time
 from enum import Enum, IntEnum, auto
+from functools import partial
 from typing import Any, ClassVar, Dict, Generator, List, Optional, Union
 from uuid import UUID
 from weakref import WeakValueDictionary
@@ -497,6 +498,114 @@ class RootTree(QtCore.QAbstractItemModel):
         num_children = item.childCount()
         self.beginInsertRows(parent, 0, num_children)
         self.endInsertRows()
+
+
+class RootTreeView(QtWidgets.QTreeView):
+    """
+    Tree view for displaying an Entry.
+    Contains a standard context menu and action set
+    """
+
+    _model: Optional[RootTree] = None
+    data_updated: ClassVar[QtCore.Signal] = QtCore.Signal()
+
+    def __init__(
+        self,
+        *args,
+        client: Optional[Client] = None,
+        entry: Optional[Entry] = None,
+        open_page_slot: Optional[OpenPageSlot] = None,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        self._client = client
+        self.data = entry
+        self.open_page_slot = open_page_slot
+
+        self.setup_ui()
+
+    def setup_ui(self) -> None:
+        # Configure basic settings
+        self.maybe_setup_model()
+
+        self.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self.customContextMenuRequested.connect(self._tree_context_menu)
+        self.setExpandsOnDoubleClick(False)
+        self.doubleClicked.connect(self.open_index)
+
+    @property
+    def client(self):
+        return self._client
+
+    @client.setter
+    def client(self, client: Client):
+        self._set_client(client)
+
+    def _set_client(self, client: Client):
+        if client is self._client:
+            return
+
+        if not isinstance(client, Client):
+            raise ValueError("Provided client is not a superscore Client")
+
+        self._client = client
+        self.maybe_setup_model()
+
+    def set_data(self, data: Any):
+        """Set the data for this view, re-setup ui"""
+        if not isinstance(data, (Root, Entry)):
+            raise ValueError(
+                f"Attempted to set an incompatable data type ({type(data)})"
+            )
+        self.data = data
+        self.maybe_setup_model()
+
+    def maybe_setup_model(self):
+        if self.client is None:
+            logger.debug("Client not set, cannot initialize model")
+            return
+
+        if self.data is None:
+            logger.debug("data not set, cannot initialize model")
+            return
+
+        self._model = RootTree(base_entry=self.data, client=self.client)
+        self.setModel(self._model)
+        self._model.dataChanged.connect(self.data_updated)
+
+        self.data_updated.emit()
+
+    def _tree_context_menu(self, pos: QtCore.QPoint) -> None:
+        index: QtCore.QModelIndex = self.indexAt(pos)
+        if index is not None and index.data() is not None:
+            entry: Entry = index.internalPointer()._data
+            menu = self.create_context_menu(entry)
+
+            menu.exec_(self.mapToGlobal(pos))
+
+    def create_context_menu(self, entry: Entry) -> QtWidgets.QMenu:
+        """
+        Default method for creating the context menu.
+        Overload/replace this method if you would like to change this behavior
+        """
+        menu = QtWidgets.QMenu(self)
+        open_action = menu.addAction(
+            f'&Open Detailed {type(entry).__name__} page'
+        )
+        # WeakPartialMethodSlot may not be needed, menus are transient
+        open_action.triggered.connect(partial(self.open_page, entry))
+
+        return menu
+
+    def open_index(self, index: QtCore.QModelIndex) -> None:
+        entry: Entry = index.internalPointer()._data
+        print(f'double click on : {type(entry)}')
+        self.open_page(entry)
+
+    def open_page(self, entry):
+        """Simple wrapper around the open page slot"""
+        if self.open_page_slot is not None:
+            self.open_page_slot(entry)
 
 
 class HeaderEnum(IntEnum):


### PR DESCRIPTION
## Description
- Adds common `RootTreeView` which holds the `RootTree` model
  - Upstreams standard settings and context menu support
- Fills the top-level entry whenever `RootTree` model is created, to ensure at least first level of children display

## Motivation and Context
Closes #101 

## How Has This Been Tested?
Interactively, and some tests have been added

Now you can double-click-to-open and right-click inside of other pages that have Tree Views
Now all pages with tree views will open with at least the first set of children populated.  

## Where Has This Been Documented?
This PR

![image](https://github.com/user-attachments/assets/79c0dab7-619a-4281-9114-d30b45618ca2)

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
