### PR TITLE
ENH: add search term for retrieving Entries that are nested under an ancestor

### DIFF
--- a/docs/source/upcoming_release_notes/108-ancestor_search_option.rst
+++ b/docs/source/upcoming_release_notes/108-ancestor_search_option.rst
@@ -1,0 +1,22 @@
+108 ancestor search option
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Add "ancestor" search option, returning entries reachable from the ancestor
+
+Bugfixes
+--------
+- Flatten and cache entries in FilestoreBackend.save_entry
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- shilorigins

--- a/superscore/backends/filestore.py
+++ b/superscore/backends/filestore.py
@@ -264,7 +264,7 @@ class FilestoreBackend(_Backend):
             if db.get(entry.uuid):
                 raise BackendError("Entry already exists, try updating the entry "
                                    "instead of saving it")
-            db[entry.uuid] = entry
+            self.flatten_and_cache(entry)
             self._root.entries.append(entry)
 
     def update_entry(self, entry: Entry) -> None:

--- a/superscore/backends/filestore.py
+++ b/superscore/backends/filestore.py
@@ -295,6 +295,7 @@ class FilestoreBackend(_Backend):
                     if attr == "entry_type":
                         conditions.append(isinstance(entry, target))
                     elif attr == "ancestor":
+                        # `target` must be UUID since `reachable` is cached
                         conditions.append(entry.uuid in reachable(target))
                     else:
                         try:
@@ -306,7 +307,7 @@ class FilestoreBackend(_Backend):
                 if all(conditions):
                     yield entry
 
-    def _gather_reachable(self, ancestor: UUID) -> Container[UUID]:
+    def _gather_reachable(self, ancestor: Union[Entry, UUID]) -> Container[UUID]:
         """
         Finds all entries accessible from ancestor, including ancestor, and returns
         their UUIDs. This makes it easy to check if one entry is hierarchically under another.

--- a/superscore/tests/test_backend.py
+++ b/superscore/tests/test_backend.py
@@ -202,3 +202,16 @@ def test_update_entry(backends: _Backend):
     p1 = Parameter()
     with pytest.raises(BackendError):
         backends.update_entry(p1)
+
+
+@pytest.mark.parametrize("filestore_backend", [("linac_data",)], indirect=True)
+def test_gather_reachable(filestore_backend: _Backend):
+    # top-level snapshot
+    reachable = filestore_backend._gather_reachable(UUID("06282731-33ea-4270-ba14-098872e627dc"))
+    assert len(reachable) == 32
+    assert UUID("927ef6cb-e45f-4175-aa5f-6c6eec1f3ae4") in reachable
+
+    # direct parent snapshot
+    reachable = filestore_backend._gather_reachable(UUID("2f709b4b-79da-4a8b-8693-eed2c389cb3a"))
+    assert len(reachable) == 3
+    assert UUID("927ef6cb-e45f-4175-aa5f-6c6eec1f3ae4") in reachable

--- a/superscore/tests/test_backend.py
+++ b/superscore/tests/test_backend.py
@@ -211,7 +211,8 @@ def test_gather_reachable(filestore_backend: _Backend):
     assert len(reachable) == 32
     assert UUID("927ef6cb-e45f-4175-aa5f-6c6eec1f3ae4") in reachable
 
-    # direct parent snapshot
-    reachable = filestore_backend._gather_reachable(UUID("2f709b4b-79da-4a8b-8693-eed2c389cb3a"))
+    # direct parent snapshot; works with UUID or Entry
+    entry = filestore_backend.get_entry(UUID("2f709b4b-79da-4a8b-8693-eed2c389cb3a"))
+    reachable = filestore_backend._gather_reachable(entry)
     assert len(reachable) == 3
     assert UUID("927ef6cb-e45f-4175-aa5f-6c6eec1f3ae4") in reachable

--- a/superscore/tests/test_client.py
+++ b/superscore/tests/test_client.py
@@ -231,5 +231,20 @@ def test_search_entries_by_ancestor(sample_client: Client):
     assert len(entries) == 1
 
 
+@pytest.mark.parametrize("filestore_backend", [("linac_with_comparison_snapshot",)], indirect=True)
+def test_search_caching(sample_client: Client):
+    entry = sample_client.backend.get_entry(UUID("2f709b4b-79da-4a8b-8693-eed2c389cb3a"))
+    result = sample_client.search(
+        ("ancestor", "eq", UUID("2f709b4b-79da-4a8b-8693-eed2c389cb3a")),
+    )
+    assert len(tuple(result)) == 3
+    entry.children = []
+    sample_client.backend.update_entry(entry)
+    result = sample_client.search(
+        ("ancestor", "eq", UUID("2f709b4b-79da-4a8b-8693-eed2c389cb3a")),
+    )
+    assert len(tuple(result)) == 1  # update is picked up in new search
+
+
 def test_parametrized_filestore_empty(sample_client: Client):
     assert len(list(sample_client.search())) == 0

--- a/superscore/tests/test_client.py
+++ b/superscore/tests/test_client.py
@@ -211,8 +211,24 @@ def test_fill_depth(fill_depth: int):
 
 
 @pytest.mark.parametrize("filestore_backend", [("linac_with_comparison_snapshot",)], indirect=True)
-def test_parametrized_filestore(sample_client: Client):
-    assert len(list(sample_client.search())) > 0
+def test_search_entries_by_ancestor(sample_client: Client):
+    entries = tuple(sample_client.search(
+        ("entry_type", "eq", Setpoint),
+        ("pv_name", "eq", "LASR:GUNB:TEST1"),
+    ))
+    assert len(entries) == 2
+    entries = tuple(sample_client.search(
+        ("entry_type", "eq", Setpoint),
+        ("pv_name", "eq", "LASR:GUNB:TEST1"),
+        ("ancestor", "eq", UUID("06282731-33ea-4270-ba14-098872e627dc")),  # top-level snapshot
+    ))
+    assert len(entries) == 1
+    entries = tuple(sample_client.search(
+        ("entry_type", "eq", Setpoint),
+        ("pv_name", "eq", "LASR:GUNB:TEST1"),
+        ("ancestor", "eq", UUID("2f709b4b-79da-4a8b-8693-eed2c389cb3a")),  # direct parent
+    ))
+    assert len(entries) == 1
 
 
 def test_parametrized_filestore_empty(sample_client: Client):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Add support for `ancestor` `SearchTerm` to `FilestoreBackend.search`
Add `FilestoreBackend._gather_progeny` utility method 

Closes #102 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With an `Entry` in one `Nestable`, it is impossible to retrieve the corresponding `Entry` in another `Nestable` using the existing `SearchTerms`.  The attributes of the known `Entry` do not reliably correspond to attributes of the desired `Entry`, other than the `.pv_name` or `.title`, so it is necessary to be able to limit searches to `Entry`s that are nested under a known `Nestable`.

A concrete use case is comparing snapshots.  For each PV in the first snapshot, the corresponding PV must be found in the second snapshot using only the PV string.  This becomes possible using the new search term.

The current implementation uses a utility method to gather all `Entry`s nested under an ancestor `Entry`.  This enables caching the result using `functools.cache`, which lets us avoid:
1. Traversing the ancestor's DAG for each entry we check
2. Iterating over the search terms in advance in order to gather all progeny before checking the search conditions

Calling `cache` directly rather than as a decorator limits the caching to each `FilestoreBackend.search` call, so changes to the data between searches are reflected properly. I believe each cache should be garbage collected after each search, but I haven't been able to verify this yet.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A unit test in `tests/test_backend` and an integration test in `tests/test_client`.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
