### PR TITLE
Devagr/entry visitor

### DIFF
--- a/superscore/backends/core.py
+++ b/superscore/backends/core.py
@@ -1,22 +1,12 @@
 """
 Base superscore data storage backend interface
 """
-import re
-from collections.abc import Container, Generator
-from typing import NamedTuple, Union
+from collections.abc import Generator
+from typing import Union
 from uuid import UUID
 
 from superscore.model import Entry, Root
-from superscore.type_hints import AnyEpicsType
-
-SearchTermValue = Union[AnyEpicsType, Container[AnyEpicsType], tuple[AnyEpicsType, ...]]
-SearchTermType = tuple[str, str, SearchTermValue]
-
-
-class SearchTerm(NamedTuple):
-    attr: str
-    operator: str
-    value: SearchTermValue
+from superscore.search_term import SearchTermType
 
 
 class _Backend:
@@ -66,41 +56,6 @@ class _Backend:
         - like (fuzzy match, depends on type of value)
         """
         raise NotImplementedError
-
-    @staticmethod
-    def compare(op: str, data: AnyEpicsType, target: SearchTermValue) -> bool:
-        """
-        Return whether data and target satisfy the op comparator, typically during application
-        of a search filter. Possible values of op are detailed in _Backend.search
-
-        Parameters
-        ----------
-        op: str
-            one of the comparators that all backends must support, detailed in _Backend.search
-        data: AnyEpicsType | Tuple[AnyEpicsType]
-            data from an Entry that is being used to decide whether the Entry passes a filter
-        target: AnyEpicsType | Tuple[AnyEpicsType]
-            the filter value
-
-        Returns
-        -------
-        bool
-            whether data and target satisfy the op condition
-        """
-        if op == "eq":
-            return data == target
-        elif op == "lt":
-            return data <= target
-        elif op == "gt":
-            return data >= target
-        elif op == "in":
-            return data in target
-        elif op == "like":
-            if isinstance(data, UUID):
-                data = str(data)
-            return re.search(target, data)
-        else:
-            raise ValueError(f"SearchTerm does not support operator \"{op}\"")
 
     @property
     def root(self) -> Root:

--- a/superscore/backends/filestore.py
+++ b/superscore/backends/filestore.py
@@ -17,6 +17,7 @@ from superscore.backends.core import SearchTermType, _Backend
 from superscore.errors import BackendError
 from superscore.model import Entry, Root
 from superscore.utils import build_abs_path
+from superscore.visitor import SearchVisitor
 
 logger = logging.getLogger(__name__)
 
@@ -285,22 +286,10 @@ class FilestoreBackend(_Backend):
         Keys are attributes on `Entry` subclasses, or special keywords.
         Values can be a single value or a tuple of values depending on operator.
         """
-        with self._load_and_store_context() as db:
-            for entry in db.values():
-                conditions = []
-                for attr, op, target in search_terms:
-                    # TODO: search for child pvs?
-                    if attr == "entry_type":
-                        conditions.append(isinstance(entry, target))
-                    else:
-                        try:
-                            # check entry attribute by name
-                            value = getattr(entry, attr)
-                            conditions.append(self.compare(op, value, target))
-                        except AttributeError:
-                            conditions.append(False)
-                if all(conditions):
-                    yield entry
+        visitor = SearchVisitor(self, *search_terms)
+        root = self.root
+        visitor.visit(root)
+        yield from visitor.matches
 
     @contextlib.contextmanager
     def _load_and_store_context(self) -> Generator[Dict[UUID, Any], None, None]:

--- a/superscore/backends/test.py
+++ b/superscore/backends/test.py
@@ -9,6 +9,7 @@ from superscore.backends.core import SearchTermType, _Backend
 from superscore.errors import (BackendError, EntryExistsError,
                                EntryNotFoundError)
 from superscore.model import Entry, Nestable, Root
+from superscore.visitor import SearchVisitor
 
 
 class TestBackend(_Backend):
@@ -75,18 +76,7 @@ class TestBackend(_Backend):
         return self._root
 
     def search(self, *search_terms: SearchTermType):
-        for entry in self._entry_cache.values():
-            conditions = []
-            for attr, op, target in search_terms:
-                # TODO: search for child pvs?
-                if attr == "entry_type":
-                    conditions.append(isinstance(entry, target))
-                else:
-                    try:
-                        # check entry attribute by name
-                        value = getattr(entry, attr)
-                        conditions.append(self.compare(op, value, target))
-                    except AttributeError:
-                        conditions.append(False)
-            if all(conditions):
-                yield entry
+        visitor = SearchVisitor(self, *search_terms)
+        root = self.root
+        visitor.visit(root)
+        yield from visitor.matches

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -7,13 +7,14 @@ from typing import Any, Dict, Generator, Iterable, List, Optional, Union
 from uuid import UUID
 
 from superscore.backends import get_backend
-from superscore.backends.core import SearchTerm, SearchTermType, _Backend
+from superscore.backends.core import _Backend
 from superscore.compare import DiffItem, EntryDiff, walk_find_diff
 from superscore.control_layers import ControlLayer, EpicsData
 from superscore.control_layers.status import TaskStatus
 from superscore.errors import CommunicationError
 from superscore.model import (Collection, Entry, Nestable, Parameter, Readback,
                               Setpoint, Snapshot)
+from superscore.search_term import SearchTerm, SearchTermType
 from superscore.utils import build_abs_path
 
 logger = logging.getLogger(__name__)

--- a/superscore/model.py
+++ b/superscore/model.py
@@ -301,7 +301,7 @@ class Snapshot(Nestable, Entry):
 @dataclass
 class Root:
     """Top level structure holding ``Entry``'s.  Denotes the top of the tree"""
-    meta_id: UUID = _root_uuid
+    uuid: UUID = _root_uuid
     entries: List[Entry] = field(default_factory=list)
 
     def accept(self, visitor) -> None:

--- a/superscore/search_term.py
+++ b/superscore/search_term.py
@@ -1,0 +1,12 @@
+from typing import Container, NamedTuple, Union
+
+from superscore.type_hints import AnyEpicsType
+
+SearchTermValue = Union[AnyEpicsType, Container[AnyEpicsType], tuple[AnyEpicsType, ...]]
+SearchTermType = tuple[str, str, SearchTermValue]
+
+
+class SearchTerm(NamedTuple):
+    attr: str
+    operator: str
+    value: SearchTermValue

--- a/superscore/tests/db/filestore.json
+++ b/superscore/tests/db/filestore.json
@@ -1,5 +1,5 @@
 {
-  "meta_id": "a28cd77d-cc92-46cc-90cb-758f0f36f041",
+  "uuid": "a28cd77d-cc92-46cc-90cb-758f0f36f041",
   "entries": [
     {
       "Parameter": {

--- a/superscore/tests/test_backend.py
+++ b/superscore/tests/test_backend.py
@@ -3,10 +3,11 @@ from uuid import UUID
 
 import pytest
 
-from superscore.backends.core import SearchTerm, _Backend
+from superscore.backends.core import _Backend
 from superscore.errors import (BackendError, EntryExistsError,
                                EntryNotFoundError)
 from superscore.model import Collection, Parameter, Snapshot
+from superscore.search_term import SearchTerm
 
 
 class TestTestBackend:

--- a/superscore/tests/test_client.py
+++ b/superscore/tests/test_client.py
@@ -211,8 +211,24 @@ def test_fill_depth(fill_depth: int):
 
 
 @pytest.mark.parametrize("filestore_backend", [("linac_with_comparison_snapshot",)], indirect=True)
-def test_parametrized_filestore(sample_client: Client):
-    assert len(list(sample_client.search())) > 0
+def test_search_entries_by_ancestor(sample_client: Client):
+    entries = tuple(sample_client.search(
+        ("entry_type", "eq", Setpoint),
+        ("pv_name", "eq", "LASR:GUNB:TEST1"),
+    ))
+    assert len(entries) == 2
+    entries = tuple(sample_client.search(
+        ("entry_type", "eq", Setpoint),
+        ("pv_name", "eq", "LASR:GUNB:TEST1"),
+        ("ancestor", "eq", UUID("06282731-33ea-4270-ba14-098872e627dc")),  # top-level snapshot
+    ))
+    assert len(entries) == 1
+    entries = tuple(sample_client.search(
+        ("entry_type", "eq", Setpoint),
+        ("pv_name", "eq", "LASR:GUNB:TEST1"),
+        ("ancestor", "eq", UUID("2f709b4b-79da-4a8b-8693-eed2c389cb3a")),  # direct parent
+    ))
+    assert len(entries) == 1
 
 
 def test_parametrized_filestore_empty(sample_client: Client):

--- a/superscore/tests/test_client.py
+++ b/superscore/tests/test_client.py
@@ -5,7 +5,6 @@ from uuid import UUID
 
 import pytest
 
-from superscore.backends.core import SearchTerm
 from superscore.backends.filestore import FilestoreBackend
 from superscore.backends.test import TestBackend
 from superscore.client import Client
@@ -13,6 +12,7 @@ from superscore.control_layers import EpicsData
 from superscore.errors import CommunicationError
 from superscore.model import (Collection, Entry, Nestable, Parameter, Readback,
                               Root, Setpoint)
+from superscore.search_term import SearchTerm
 from superscore.tests.conftest import MockTaskStatus, nest_depth
 
 SAMPLE_CFG = Path(__file__).parent / 'config.cfg'

--- a/superscore/tests/test_compare.py
+++ b/superscore/tests/test_compare.py
@@ -4,12 +4,12 @@ from uuid import UUID
 
 import pytest
 
-from superscore.backends.core import SearchTerm
 from superscore.client import Client
 from superscore.compare import (AttributePath, DiffItem, EntryDiff,
                                 walk_find_diff)
 from superscore.model import (Collection, Entry, Parameter, Readback, Setpoint,
                               Severity, Snapshot, Status)
+from superscore.search_term import SearchTerm
 
 
 def simplify_path(path: AttributePath) -> AttributePath:

--- a/superscore/visitor.py
+++ b/superscore/visitor.py
@@ -1,0 +1,49 @@
+""""""
+from collections.abc import Union
+from uuid import UUID
+
+from superscore.backends import _Backend
+from superscore.model import (Collection, Entry, Parameter, Readback, Root,
+                              Setpoint, Snapshot)
+
+
+class EntryVisitor:
+    """"""
+    def __init__(self, backend: _Backend):
+        self.backend = backend
+
+    def visit(self, entry: Union[Entry, Root, UUID]) -> None:
+        if isinstance(entry, UUID):
+            entry = self.backend.get_entry(entry)
+        entry.accept(self)
+        return
+
+    def visitParameter(self, parameter: Parameter) -> None:
+        raise NotImplementedError
+
+    def visitSetpoint(self, setpoint: Setpoint) -> None:
+        raise NotImplementedError
+
+    def visitReadback(self, readback: Readback) -> None:
+        raise NotImplementedError
+
+    def visitCollection(self, collection: Collection) -> None:
+        raise NotImplementedError
+
+    def visitSnapshot(self, snapshot: Snapshot) -> None:
+        raise NotImplementedError
+
+    def visitRoot(self, root: Root) -> None:
+        raise NotImplementedError
+
+
+class FillUUIDVisitor(EntryVisitor):
+    pass
+
+
+class SnapVisitor(EntryVisitor):
+    pass
+
+
+class SearchVisitor(EntryVisitor):
+    pass

--- a/superscore/visitor.py
+++ b/superscore/visitor.py
@@ -1,10 +1,21 @@
 """"""
-from collections.abc import Union
+import re
+from typing import Container, Iterable, NamedTuple, Union
 from uuid import UUID
 
 from superscore.backends import _Backend
 from superscore.model import (Collection, Entry, Parameter, Readback, Root,
                               Setpoint, Snapshot)
+from superscore.type_hints import AnyEpicsType
+
+SearchTermValue = Union[AnyEpicsType, Container[AnyEpicsType], tuple[AnyEpicsType, ...]]
+SearchTermType = tuple[str, str, SearchTermValue]
+
+
+class SearchTerm(NamedTuple):
+    attr: str
+    operator: str
+    value: SearchTermValue
 
 
 class EntryVisitor:
@@ -46,4 +57,76 @@ class SnapVisitor(EntryVisitor):
 
 
 class SearchVisitor(EntryVisitor):
-    pass
+    def __init__(self, *search_terms: Iterable[SearchTerm], **kwargs):
+        super().__init__(self, **kwargs)
+        self.search_terms = search_terms
+        self.matches = []
+
+    def _check_match(self, entry: Union[Entry, Root]) -> bool:
+        conditions = []
+        for attr, op, target in self.search_terms:
+            # TODO: search for child pvs?
+            if attr == "entry_type":
+                conditions.append(isinstance(entry, target))
+            else:
+                try:
+                    # check entry attribute by name
+                    value = getattr(entry, attr)
+                    conditions.append(self.compare(op, value, target))
+                except AttributeError:
+                    conditions.append(False)
+        if all(conditions):
+            self.matches.append(entry)
+
+    def visitParameter(self, parameter: Parameter) -> None:
+        self._check_match(parameter)
+
+    def visitSetpoint(self, setpoint: Setpoint) -> None:
+        self._check_match(setpoint)
+
+    def visitReadback(self, readback: Readback) -> None:
+        self._check_match(readback)
+
+    def visitCollection(self, collection: Collection) -> None:
+        self._check_match(collection)
+
+    def visitSnapshot(self, snapshot: Snapshot) -> None:
+        self._check_match(snapshot)
+
+    def visitRoot(self, root: Root) -> None:
+        self._check_match(root)
+
+    @staticmethod
+    def compare(op: str, data: AnyEpicsType, target: SearchTermValue) -> bool:
+        """
+        Return whether data and target satisfy the op comparator, typically during application
+        of a search filter. Possible values of op are detailed in _Backend.search
+
+        Parameters
+        ----------
+        op: str
+            one of the comparators that all backends must support, detailed in _Backend.search
+        data: AnyEpicsType | Tuple[AnyEpicsType]
+            data from an Entry that is being used to decide whether the Entry passes a filter
+        target: AnyEpicsType | Tuple[AnyEpicsType]
+            the filter value
+
+        Returns
+        -------
+        bool
+            whether data and target satisfy the op condition
+        """
+        if op == "eq":
+            return data == target
+        elif op == "lt":
+            return data <= target
+        elif op == "gt":
+            return data >= target
+        elif op == "in":
+            return data in target
+        elif op == "like":
+            if isinstance(data, UUID):
+                data = str(data)
+            return re.search(target, data)
+        else:
+            raise ValueError(f"SearchTerm does not support operator \"{op}\"")

--- a/superscore/visitor.py
+++ b/superscore/visitor.py
@@ -1,26 +1,17 @@
 """"""
 import re
-from typing import Container, Iterable, NamedTuple, Union
+from typing import Iterable, Union
 from uuid import UUID
 
-from superscore.backends import _Backend
 from superscore.model import (Collection, Entry, Parameter, Readback, Root,
                               Setpoint, Snapshot)
+from superscore.search_term import SearchTerm, SearchTermValue
 from superscore.type_hints import AnyEpicsType
-
-SearchTermValue = Union[AnyEpicsType, Container[AnyEpicsType], tuple[AnyEpicsType, ...]]
-SearchTermType = tuple[str, str, SearchTermValue]
-
-
-class SearchTerm(NamedTuple):
-    attr: str
-    operator: str
-    value: SearchTermValue
 
 
 class EntryVisitor:
     """"""
-    def __init__(self, backend: _Backend):
+    def __init__(self, backend):
         self.backend = backend
 
     def visit(self, entry: Union[Entry, Root, UUID]) -> None:
@@ -57,8 +48,8 @@ class SnapVisitor(EntryVisitor):
 
 
 class SearchVisitor(EntryVisitor):
-    def __init__(self, *search_terms: Iterable[SearchTerm], **kwargs):
-        super().__init__(self, **kwargs)
+    def __init__(self, backend, *search_terms: Iterable[SearchTerm]):
+        super().__init__(backend)
         self.search_terms = search_terms
         self.matches = []
 
@@ -94,7 +85,7 @@ class SearchVisitor(EntryVisitor):
         self._check_match(snapshot)
 
     def visitRoot(self, root: Root) -> None:
-        self._check_match(root)
+        return
 
     @staticmethod
     def compare(op: str, data: AnyEpicsType, target: SearchTermValue) -> bool:

--- a/superscore/widgets/page/search.py
+++ b/superscore/widgets/page/search.py
@@ -8,9 +8,9 @@ import qtawesome as qta
 from dateutil import tz
 from qtpy import QtCore, QtWidgets
 
-from superscore.backends.core import SearchTerm
 from superscore.client import Client
 from superscore.model import Collection, Entry, Readback, Setpoint, Snapshot
+from superscore.search_term import SearchTerm
 from superscore.type_hints import OpenPageSlot
 from superscore.widgets import ICON_MAP
 from superscore.widgets.core import Display

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -15,13 +15,13 @@ import numpy as np
 import qtawesome as qta
 from qtpy import QtCore, QtGui, QtWidgets
 
-from superscore.backends.core import SearchTerm
 from superscore.client import Client
 from superscore.control_layers import EpicsData
 from superscore.errors import EntryNotFoundError
 from superscore.model import (Collection, Entry, Nestable, Parameter, Readback,
                               Root, Setpoint, Severity, Snapshot, Status)
 from superscore.qt_helpers import QDataclassBridge
+from superscore.search_term import SearchTerm
 from superscore.type_hints import OpenPageSlot
 from superscore.widgets import ICON_MAP
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Implement `EntryVisitor` abstract class, with corresponding `Entry.accept` methods
Implement `SearchVisitor` as the first concrete visitor
Add `ancestor` search option to `SearchVisitor`

Relates to #106 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using a visitor pattern will let us decouple `Entry` DAG traversal from specific components, such as the `Client` or concrete `_Backend` subclasses. This should make it easier to do things like collect and search entries, fill UUIDs, and save snapshots without having to re-implement traversal logic in multiple places.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing search tests cover the new `SearchVisitor`.
## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
