### PR TITLE
GUI: add Diff-view page

### DIFF
--- a/docs/source/upcoming_release_notes/112-gui_diff_page.rst
+++ b/docs/source/upcoming_release_notes/112-gui_diff_page.rst
@@ -1,0 +1,23 @@
+112 gui_diff_page
+#################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Adds DiffPage for comparing two Entry's with diff highlighting
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Refactors context menu generation, applying it to all common views
+- Adds a QtSingleton class for singleton QObject subclasses that want to hold singleton signals
+
+Contributors
+------------
+- tangkong

--- a/superscore/compare.py
+++ b/superscore/compare.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, fields, is_dataclass
+from enum import Enum, auto
 from typing import Any, Generator, Iterable, List, Optional, Tuple, Union
 
 from superscore.model import Entry
@@ -12,6 +13,12 @@ from superscore.model import Entry
 # enum value:           ("__enum__", enum_member: Enum)
 # set entry:            ("__set__", set_member: str)
 AttributePath = List[Tuple[Any, Any]]
+
+
+class DiffType(Enum):
+    DELETED = auto()
+    MODIFIED = auto()
+    ADDED = auto()
 
 
 @dataclass
@@ -48,6 +55,17 @@ class DiffItem:
         repr_str += f": ({orig_val_str}->{new_val_str})"
 
         return repr_str
+
+    @property
+    def type(self) -> DiffType:
+        if (self.original_value is not None) and (self.new_value is None):
+            return DiffType.DELETED
+        elif (self.original_value is None) and (self.new_value is not None):
+            return DiffType.ADDED
+        elif (self.original_value is not None) and (self.new_value is not None):
+            return DiffType.MODIFIED
+        else:
+            raise ValueError("DiffItem original and new values are both None")
 
 
 @dataclass

--- a/superscore/tests/test_page.py
+++ b/superscore/tests/test_page.py
@@ -11,6 +11,7 @@ from superscore.control_layers._base_shim import EpicsData
 from superscore.model import (Collection, Parameter, Readback, Setpoint,
                               Snapshot)
 from superscore.widgets.page.collection_builder import CollectionBuilderPage
+from superscore.widgets.page.diff import DiffPage
 from superscore.widgets.page.entry import (BaseParameterPage, CollectionPage,
                                            ParameterPage, ReadbackPage,
                                            SetpointPage, SnapshotPage)
@@ -90,6 +91,35 @@ def restore_page(qtbot: QtBot, sample_client: Client, simple_snapshot: Snapshot)
     page.close()
 
 
+@pytest.fixture
+def diff_page(qtbot: QtBot, sample_client: Client):
+    l_snapshot = Snapshot(
+        title="l_snap",
+        description="l desc",
+        children=[
+            Setpoint(pv_name="MY:SET", data=1),
+            Readback(pv_name="MY:RBV", data=1),
+        ]
+    )
+    r_snapshot = Snapshot(
+        title="r_snap",
+        description="r desc",
+        children=[
+            Setpoint(pv_name="MY:SET", data=2),
+            Readback(pv_name="MY:RBV", data=1),
+            Readback(pv_name="MY:RBV2", data=2),
+        ]
+    )
+    page = DiffPage(
+        client=sample_client,
+        l_entry=l_snapshot,
+        r_entry=r_snapshot,
+    )
+    qtbot.addWidget(page)
+    yield page
+    page.close()
+
+
 @pytest.mark.parametrize(
     'page',
     [
@@ -101,6 +131,7 @@ def restore_page(qtbot: QtBot, sample_client: Client, simple_snapshot: Snapshot)
         "search_page",
         "collection_builder_page",
         "restore_page",
+        "diff_page",
     ]
 )
 def test_page_smoke(page: str, request: pytest.FixtureRequest):

--- a/superscore/ui/diff_page.ui
+++ b/superscore/ui/diff_page.ui
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>692</width>
+    <height>587</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QWidget" name="meta_placeholder" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QSplitter" name="horiz_splitter">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <widget class="QSplitter" name="l_vert_splitter">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <widget class="RootTreeView" name="l_tree_view"/>
+      <widget class="LivePVTableView" name="l_pv_table_view"/>
+      <widget class="NestableTableView" name="l_nest_table_view"/>
+     </widget>
+     <widget class="QSplitter" name="r_vert_splitter">
+      <property name="orientation">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <widget class="RootTreeView" name="r_tree_view"/>
+      <widget class="LivePVTableView" name="r_pv_table_view"/>
+      <widget class="NestableTableView" name="r_nest_table_view"/>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>LivePVTableView</class>
+   <extends>QTableView</extends>
+   <header>superscore.widgets.views</header>
+  </customwidget>
+  <customwidget>
+   <class>NestableTableView</class>
+   <extends>QTableView</extends>
+   <header>superscore.widgets.views</header>
+  </customwidget>
+  <customwidget>
+   <class>RootTreeView</class>
+   <extends>QTreeView</extends>
+   <header>superscore.widgets.views</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/superscore/widgets/core.py
+++ b/superscore/widgets/core.py
@@ -8,7 +8,7 @@ from typing import ClassVar, List
 from weakref import WeakValueDictionary
 
 from pcdsutils.qt.designer_display import DesignerDisplay
-from qtpy import QtWidgets
+from qtpy import QtCore, QtWidgets
 
 from superscore.qt_helpers import QDataclassBridge, QDataclassList
 from superscore.type_hints import AnyDataclass
@@ -396,3 +396,30 @@ class TagsElem(Display, QtWidgets.QWidget):
         Tell the QTagsWidget when our delete button is clicked.
         """
         self.tags_widget.remove_item(self)
+
+
+class QtSingleton(type(QtCore.QObject), type):
+    """
+    Qt specific singleton implementation, needed to ensure signals are shared
+    between instances.  Adapted from
+    https://stackoverflow.com/questions/59459770/receiving-pyqtsignal-from-singleton
+
+    The more common __new__ - based singleton pattern does result in the QObject
+    being a singleton, but the bound signals lose their connections whenever the
+    instance is re-acquired.  I do not understand but this works
+
+    To use this, specify `QtSingleton` as a metaclass:
+
+    .. code-block:: python
+        class SingletonClass(QtCore.QObject, metaclass=QtSingleton):
+            shared_signal: ClassVar[QtCore.Signal] = QtCore.Signal()
+
+    """
+    def __init__(cls, name, bases, dict):
+        super().__init__(name, bases, dict)
+        cls._instance = None
+
+    def __call__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super().__call__(*args, **kwargs)
+        return cls._instance

--- a/superscore/widgets/page/diff.py
+++ b/superscore/widgets/page/diff.py
@@ -25,7 +25,7 @@ DIFF_COLOR_MAP = {
     DiffType.DELETED: QtGui.QColor(255, 0, 0, alpha=100),
     DiffType.MODIFIED: QtGui.QColor(255, 255, 0, alpha=100),
     DiffType.ADDED: QtGui.QColor(0, 255, 0, alpha=100),
-    None: None,
+    None: None,  # the no modification case, do not change background color
 }
 
 
@@ -39,8 +39,10 @@ class BiDict(dict):
         self.inverse = {}
 
     def __setitem__(self, key, value):
+        # setting in the standard direction to a new value
+        # must remove the inverse oldvalue-key pair
         if key in self:
-            self.inverse[self[key]].remove(key)
+            del self.inverse[self[key]]
         super().__setitem__(key, value)
         self.inverse[value] = key
 

--- a/superscore/widgets/page/diff.py
+++ b/superscore/widgets/page/diff.py
@@ -1,0 +1,214 @@
+from enum import Flag
+from functools import partial
+from typing import Any, Dict, Optional, Set
+from uuid import UUID
+
+from PyQt5.QtGui import QCloseEvent
+from qtpy import QtCore, QtGui, QtWidgets
+
+from superscore.client import Client
+from superscore.compare import DiffType, EntryDiff
+from superscore.model import Entry
+from superscore.type_hints import OpenPageSlot
+from superscore.widgets.core import Display
+from superscore.widgets.views import (LivePVHeader, LivePVTableView,
+                                      NestableTableView, RootTree,
+                                      RootTreeView)
+
+
+class DiffRootTree(RootTree):
+    """
+    Tree model that highlights items that have been modified.
+    Reads an `EntryDiff` and assigns background colors based on modification type
+    - Red: item removed in diff
+    - Yellow: item modified in diff
+    - Green: item added in diff
+    """
+
+    color_map = {
+        DiffType.DELETED: QtGui.QColor(255, 0, 0, alpha=100),
+        DiffType.MODIFIED: QtGui.QColor(255, 255, 0, alpha=100),
+        DiffType.ADDED: QtGui.QColor(0, 255, 0, alpha=100),
+        None: None,
+    }
+
+    _diff: EntryDiff
+    _modified_uuids: Set[UUID]
+    _index_to_diff_type_cache: Dict[QtCore.QModelIndex, DiffType]
+
+    def __init__(self, *args, diff: Optional[EntryDiff] = None, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self._diff = diff
+        # a cache that stores the background color, since entries may be lazily
+        # loaded on demand.  To be cleared if data or diff are changed
+        self._index_to_diff_type_cache = {}
+        self._modified_uuids = set()
+
+    def get_background_color(self, index: QtCore.QModelIndex) -> Optional[QtGui.QColor]:
+        # do nothing if no diff is setup
+        if not self._diff:
+            return
+
+        # show entries as modified if detected on left-side
+        if index.internalPointer()._data.uuid in self._modified_uuids:
+            return self.color_map[DiffType.MODIFIED]
+
+        if index in self._index_to_diff_type_cache:
+            return self.color_map[self._index_to_diff_type_cache[index]]
+
+        # find diffs and assign a proper color
+
+        diff_type = self._get_difftype_for_index(index)
+        self._index_to_diff_type_cache[index] = diff_type
+
+        return self.color_map[diff_type]
+
+    def _get_difftype_for_index(self, index: QtCore.QModelIndex) -> Optional[DiffType]:
+        entry: Entry = index.internalPointer()._data
+        for diff_item in self._diff.diffs:
+            # deleted or added, entry is itself the changed item
+            if entry in (diff_item.original_value, diff_item.new_value):
+                return diff_item.type
+
+            # modified, entry is in the path (Match happens on left/original side)
+            if entry in (segment[0] for segment in diff_item.path):
+                # uuids are almost always changed, if so add them to let the
+                # other tree know
+                self._modified_uuids.add(entry.uuid)
+                for di in self._diff.diffs:
+                    if di.original_value == entry.uuid:
+                        self._modified_uuids.add(di.new_value)
+
+                return diff_item.type
+
+    def data(self, index: QtCore.QModelIndex, role: int) -> Any:
+        if role == QtCore.Qt.BackgroundColorRole:
+            color = self.get_background_color(index)
+            return color
+
+        return super().data(index, role)
+
+
+class Side(Flag):
+    LEFT = True
+    RIGHT = False
+
+
+class DiffPage(Display, QtWidgets.QWidget):
+    """
+    Diff Page.  Many splitters, existing views + highlighting
+    No editing (so no data widget needed for bridge)
+        - defers editing to details
+
+    Refresh behavior?
+    """
+    filename = "diff_page.ui"
+
+    horiz_splitter: QtWidgets.QSplitter  # main l_entry/r_entry splitter
+
+    l_vert_splitter: QtWidgets.QSplitter
+    l_tree_view: RootTreeView
+    l_pv_table_view: LivePVTableView
+    l_nest_table_view: NestableTableView
+
+    r_vert_splitter: QtWidgets.QSplitter
+    r_tree_view: RootTreeView
+    r_pv_table_view: LivePVTableView
+    r_nest_table_view: NestableTableView
+
+    meta_placeholder: QtWidgets.QWidget  # TODO: Clean up or make useful
+
+    def __init__(
+        self,
+        *args,
+        client: Client,
+        open_page_slot: Optional[OpenPageSlot] = None,
+        l_entry: Optional[Entry] = None,
+        r_entry: Optional[Entry] = None,
+        **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.client = client
+        self.l_entry = l_entry
+        self.r_entry = r_entry
+        self.open_page_slot = open_page_slot
+        self._modified_uuids: Set[UUID] = set()
+
+        self.widget_map = {
+            Side.LEFT: {
+                'tree': self.l_tree_view,
+                'pv': self.l_pv_table_view,
+                'nest': self.l_nest_table_view,
+                'splitter': self.l_vert_splitter
+            },
+            Side.RIGHT: {
+                'tree': self.r_tree_view,
+                'pv': self.r_pv_table_view,
+                'nest': self.r_nest_table_view,
+                'splitter': self.r_vert_splitter
+            }
+        }
+        self.setup_ui()
+
+    def setup_ui(self):
+        # Synchronize splitters
+        self.l_vert_splitter.splitterMoved.connect(partial(
+            self.sync_splitter, side=Side.RIGHT
+        ))
+        self.r_vert_splitter.splitterMoved.connect(partial(
+            self.sync_splitter, side=Side.LEFT
+        ))
+
+        # initialize trees, tables, etc
+        for side in Side:
+            pv_view: LivePVTableView = self.widget_map[side]['pv']
+            pv_view.open_page_slot = self.open_page_slot
+            pv_view.client = self.client
+            for i in [LivePVHeader.LIVE_VALUE, LivePVHeader.LIVE_SEVERITY,
+                      LivePVHeader.LIVE_STATUS]:
+                pv_view.setColumnHidden(i, True)
+
+            nest_view: NestableTableView = self.widget_map[side]['nest']
+            nest_view.client = self.client
+            pv_view.open_page_slot = self.open_page_slot
+
+        self.set_entry(self.l_entry, Side.LEFT)
+        self.set_entry(self.r_entry, Side.RIGHT)
+
+        self.calculate_diff()
+
+    def sync_splitter(self, pos: int, index: int, side: Side):
+        sizes = self.widget_map[~side]['splitter'].sizes()
+        print(side, sizes, self.widget_map[~side]['splitter'])
+        self.widget_map[side]['splitter'].setSizes(sizes)
+
+    def set_entry(self, entry: Entry, side: Side):
+        """Initialize the widgets for the ``side`` with ``entry``"""
+        tree_view: RootTreeView = self.widget_map[side]['tree']
+        tree_view.setModel(
+            DiffRootTree(base_entry=entry, client=self.client)
+        )
+
+        pv_view: LivePVTableView = self.widget_map[side]['pv']
+        pv_view.set_data(entry)
+
+        nest_view: NestableTableView = self.widget_map[side]['nest']
+        nest_view.set_data(entry)
+
+        # clear modified uuids
+        self.modified_uuids = set()
+
+    def calculate_diff(self):
+        # get diff from client method
+        # refresh tables to show highlighting
+        diff = self.client.compare(self.l_entry, self.r_entry)
+        self._diff = diff
+        for side in Side:
+            model: DiffRootTree = self.widget_map[side]["tree"].model()
+            model._diff = diff
+            model._modified_uuids = self._modified_uuids
+
+    def closeEvent(self, a0: QCloseEvent) -> None:
+        for side in Side:
+            self.widget_map[side]['pv'].close()
+        return super().closeEvent(a0)

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -512,6 +512,7 @@ class RootTreeView(QtWidgets.QTreeView):
     Tree view for displaying an Entry.
     Contains a standard context menu and action set
     """
+    _model_cls = RootTree
 
     _model: Optional[RootTree] = None
     data_updated: ClassVar[QtCore.Signal] = QtCore.Signal()
@@ -573,7 +574,7 @@ class RootTreeView(QtWidgets.QTreeView):
             logger.debug("data not set, cannot initialize model")
             return
 
-        self._model = RootTree(base_entry=self.data, client=self.client)
+        self._model = self._model_cls(base_entry=self.data, client=self.client)
         self.setModel(self._model)
         self._model.dataChanged.connect(self.data_updated)
 

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -1357,7 +1357,7 @@ class BaseDataTableView(QtWidgets.QTableView):
 
     def set_data(self, data: Any):
         """Set the data for this view, re-setup ui"""
-        if not isinstance(data, (list, Nestable)):
+        if not isinstance(data, (list, Entry)):
             raise ValueError(
                 f"Attempted to set an incompatable data type ({type(data)})"
             )


### PR DESCRIPTION
## Description
- Adds a Diff Page that subclasses the existing common views to add highlighting based on the calculated Diff
- Adds a QtSingleton class that allows singletons to hold signals.
  - Long story short, the normal `__new__` singleton creation method doesn't quite work.  While the singletons are created correctly, the bound `QtCore.Signal`'s lose their connections every time an instance is returned
  - Devan theorizes that this has to do with `__init__` doing something to the class variable signals.  I am too tired to investigate further

This description is so minimal for the amount of time I spent spinning on this 💀 

This is likely still riddled with bugs, but I want to get eyes on it before it bloats into a small planet of a diff.  I'm happy to revisit this in follow-up PRs, but I feel like there are other more pressing tasks to take on.  (And I'm tired of thinking about diffs)

Outstanding tasks:
- add comparison context menus to main window tree view (this overrides the common views, so I left it for now)
- Touchups on diff highlighting.  (I'm bad at logic-ing things)

## Motivation and Context
#48 in part

## How Has This Been Tested?
I added a smoke test.  I should have probably added more

## Where Has This Been Documented?
This PR.  I'll go through for a docstring pass shortly

Context menus have been added to all non-main-window views 
![image](https://github.com/user-attachments/assets/9fc4258b-84cc-4e81-bea6-900883b24645)

Highlighting helps, but could be more thorough / accurate
![image](https://github.com/user-attachments/assets/5a43926f-fafe-4dac-97aa-e453a19b506b)

HIghlighting for entries with PV-entries
![image](https://github.com/user-attachments/assets/0bb4e233-04a7-4e74-a8be-66a4549713ff)


## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
