### PR TITLE
BUG: check both dataclass and EntryItem in tree view in `canFetchMore`

### DIFF
--- a/docs/source/upcoming_release_notes/114-bug_tree_fetchmore_page_open.rst
+++ b/docs/source/upcoming_release_notes/114-bug_tree_fetchmore_page_open.rst
@@ -1,0 +1,22 @@
+114 bug_tree_fetchmore_page_open
+################################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Adjusts `RootTree.canFetchMore` to check both the dataclass and the ``EntryItem`` to avoid uuid-filling desyncs
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -583,8 +583,11 @@ class RootTree(QtCore.QAbstractItemModel):
 
         data = item._data
 
-        if (isinstance(data, Nestable) and
-                any(isinstance(child, UUID) for child in data.children)):
+        has_uuid_children = (
+            any(isinstance(dc_child, UUID) for dc_child in data.children)
+            or any(isinstance(ei_child._data, UUID) for ei_child in item._children)
+        )
+        if isinstance(data, Nestable) and has_uuid_children:
             return True
 
         return False

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -583,12 +583,16 @@ class RootTree(QtCore.QAbstractItemModel):
 
         data = item._data
 
-        has_uuid_children = (
-            any(isinstance(dc_child, UUID) for dc_child in data.children)
-            or any(isinstance(ei_child._data, UUID) for ei_child in item._children)
-        )
-        if isinstance(data, Nestable) and has_uuid_children:
-            return True
+        # Root should never need to be fetched, since we fill to depth
+        # of 2 when we initialize the tree, and root is always at depth 0 if
+        # present
+        if isinstance(data, Nestable):
+            if (
+                any(isinstance(dc_child, UUID) for dc_child in data.children)
+                or any(isinstance(ei_child._data, UUID) for ei_child
+                       in item._children)
+            ):
+                return True
 
         return False
 


### PR DESCRIPTION
## Description
Previously `RootTree.canFetchMore` would check the dataclass members to determine if filling was necessary.  This works within the context of a single page, but if we open the a detailed page from the tree-view the dataclass may be filled without the EntryItem getting filled.

Now that `RootTree.canFetchMore` checks both the dataclass and the `EntryItem`, this desync can be avoided

## Motivation and Context
Closes #113 

## How Has This Been Tested?
Interactively

## Where Has This Been Documented?
This PR, pre-release notes

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
