### PR TITLE
REF: create a window singleton for access throughout superscore

### DIFF
--- a/docs/source/upcoming_release_notes/115-ref_window_singleton.rst
+++ b/docs/source/upcoming_release_notes/115-ref_window_singleton.rst
@@ -1,0 +1,23 @@
+115 ref_window_singleton
+########################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Makes Window a QtSingleton, and adds an access function for use throughout superscore ui widgets
+  Uses this singleton to access methods that were passed around manually in the past as optional arguments or set attributes (open_page_slot, client)
+
+Contributors
+------------
+- tangkong

--- a/superscore/tests/conftest.py
+++ b/superscore/tests/conftest.py
@@ -17,6 +17,7 @@ from superscore.model import (Collection, Entry, Nestable, Parameter, Readback,
                               Root, Setpoint, Severity, Snapshot, Status)
 from superscore.tests.ioc import IOCFactory
 from superscore.widgets.views import EntryItem
+from superscore.widgets.window import Window
 
 
 def linac_data() -> Root:
@@ -1003,3 +1004,10 @@ def nest_depth(entry: Union[Nestable, EntryItem]) -> int:
                 q.append((child, depth+1))
 
     return max(depths)
+
+
+@pytest.fixture(autouse=True)
+def teardown_window_singleton():
+    # clean up window autouse fixture inside this module only
+    yield
+    Window._instance = None

--- a/superscore/tests/test_page.py
+++ b/superscore/tests/test_page.py
@@ -1,6 +1,6 @@
 """Largely smoke tests for various pages"""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 from pytestqt.qtbot import QtBot
@@ -219,10 +219,11 @@ def test_open_page_slot(
     page_fixture: str,
     request: pytest.FixtureRequest,
 ):
-    page: BaseParameterPage = request.getfixturevalue(page_fixture)
-    page.open_page_slot = MagicMock()
-    page.open_rbv_button.clicked.emit()
-    assert page.open_page_slot.called
+    with patch("superscore.widgets.page.entry.BaseParameterPage.open_page_slot",
+               new_callable=PropertyMock):
+        page: BaseParameterPage = request.getfixturevalue(page_fixture)
+        page.open_rbv_button.clicked.emit()
+        assert page.open_page_slot.called
 
 
 @pytest.mark.parametrize(

--- a/superscore/widgets/__init__.py
+++ b/superscore/widgets/__init__.py
@@ -20,10 +20,11 @@ ICON_MAP = _get_icon_map()
 
 def get_window():
     """
-    Return the window singleton if it already exists, to allow creating widgets
-    without creating Window
+    Return the window singleton if it already exists, to allow other widgets to
+    access its members.
     Must not be called in the code path that results from Window.__init__.
-    A good (safe) rule of thumb is never reached from any widget's __init__.
+    A good (safe) rule of thumb is to make sure this function cannot be reached
+    from any widget's __init__ method.
     Hides import in __init__ to avoid circular imports.
     """
     from .window import Window

--- a/superscore/widgets/__init__.py
+++ b/superscore/widgets/__init__.py
@@ -16,3 +16,17 @@ def _get_icon_map():
 
 
 ICON_MAP = _get_icon_map()
+
+
+def get_window():
+    """
+    Return the window singleton if it already exists, to allow creating widgets
+    without creating Window
+    Must not be called in the code path that results from Window.__init__.
+    A good (safe) rule of thumb is never reached from any widget's __init__.
+    Hides import in __init__ to avoid circular imports.
+    """
+    from .window import Window
+    if Window._instance is None:
+        return
+    return Window()

--- a/superscore/widgets/page/collection_builder.py
+++ b/superscore/widgets/page/collection_builder.py
@@ -4,7 +4,6 @@ from typing import Optional
 from qtpy import QtCore, QtWidgets
 from qtpy.QtGui import QCloseEvent
 
-from superscore.client import Client
 from superscore.model import Collection, Entry, Parameter
 from superscore.widgets.core import (DataWidget, Display, NameDescTagsWidget,
                                      WindowLinker)
@@ -46,14 +45,12 @@ class CollectionBuilderPage(Display, DataWidget, WindowLinker):
     def __init__(
         self,
         *args,
-        client: Client,
         data: Optional[Collection] = None,
         **kwargs
     ):
         if data is None:
             data = Collection()
         super().__init__(*args, data=data, **kwargs)
-        self._client = client
         self.tree_model = None
         self._coll_options: list[Collection] = []
         self._title = self.data.title

--- a/superscore/widgets/page/collection_builder.py
+++ b/superscore/widgets/page/collection_builder.py
@@ -6,8 +6,8 @@ from qtpy.QtGui import QCloseEvent
 
 from superscore.client import Client
 from superscore.model import Collection, Entry, Parameter
-from superscore.type_hints import OpenPageSlot
-from superscore.widgets.core import DataWidget, Display, NameDescTagsWidget
+from superscore.widgets.core import (DataWidget, Display, NameDescTagsWidget,
+                                     WindowLinker)
 from superscore.widgets.enhanced import FilterComboBox
 from superscore.widgets.manip_helpers import insert_widget
 from superscore.widgets.views import (BaseTableEntryModel, LivePVHeader,
@@ -17,7 +17,7 @@ from superscore.widgets.views import (BaseTableEntryModel, LivePVHeader,
 logger = logging.getLogger(__name__)
 
 
-class CollectionBuilderPage(Display, DataWidget):
+class CollectionBuilderPage(Display, DataWidget, WindowLinker):
     filename = 'collection_builder_page.ui'
     data: Collection
 
@@ -48,14 +48,12 @@ class CollectionBuilderPage(Display, DataWidget):
         *args,
         client: Client,
         data: Optional[Collection] = None,
-        open_page_slot: Optional[OpenPageSlot] = None,
         **kwargs
     ):
         if data is None:
             data = Collection()
         super().__init__(*args, data=data, **kwargs)
-        self.client = client
-        self.open_page_slot = open_page_slot
+        self._client = client
         self.tree_model = None
         self._coll_options: list[Collection] = []
         self._title = self.data.title
@@ -90,7 +88,6 @@ class CollectionBuilderPage(Display, DataWidget):
 
         self.tree_view.client = self.client
         self.tree_view.set_data(self.data)
-        self.tree_view.open_page_slot = self.open_page_slot
         self.tree_model: RootTree = self.tree_view.model()
 
         self.sub_coll_table_view.data_updated.connect(self.tree_model.refresh_tree)

--- a/superscore/widgets/page/diff.py
+++ b/superscore/widgets/page/diff.py
@@ -7,11 +7,9 @@ from uuid import UUID
 from PyQt5.QtGui import QCloseEvent
 from qtpy import QtCore, QtGui, QtWidgets
 
-from superscore.client import Client
 from superscore.compare import DiffType, EntryDiff
 from superscore.model import Entry
-from superscore.type_hints import OpenPageSlot
-from superscore.widgets.core import Display
+from superscore.widgets.core import Display, WindowLinker
 from superscore.widgets.views import (EntryItem, LivePVHeader,
                                       LivePVTableModel, LivePVTableView,
                                       NestableHeader, NestableTableModel,
@@ -246,7 +244,7 @@ class Side(Flag):
     RIGHT = False
 
 
-class DiffPage(Display, QtWidgets.QWidget):
+class DiffPage(Display, QtWidgets.QWidget, WindowLinker):
     """
     Diff View Page.  Compares two ``Entry`` objects, attempting to highlight
     differences where appropriate
@@ -285,17 +283,13 @@ class DiffPage(Display, QtWidgets.QWidget):
     def __init__(
         self,
         *args,
-        client: Client,
-        open_page_slot: Optional[OpenPageSlot] = None,
         l_entry: Optional[Entry] = None,
         r_entry: Optional[Entry] = None,
         **kwargs
     ):
         super().__init__(*args, **kwargs)
-        self.client = client
         self.l_entry = l_entry
         self.r_entry = r_entry
-        self.open_page_slot = open_page_slot
         self._linked_uuids: Dict[UUID, UUID] = BiDict()
 
         self.widget_map = {
@@ -332,13 +326,11 @@ class DiffPage(Display, QtWidgets.QWidget):
 
             pv_view: LivePVTableView = self.widget_map[side]['pv']
             pv_view._model_cls = DiffPVTableModel
-            pv_view.open_page_slot = self.open_page_slot
             pv_view.client = self.client
 
             nest_view: NestableTableView = self.widget_map[side]['nest']
             nest_view._model_cls = DiffNestableTableModel
             nest_view.client = self.client
-            nest_view.open_page_slot = self.open_page_slot
 
         self.set_entry(self.l_entry, Side.LEFT)
         self.set_entry(self.r_entry, Side.RIGHT)

--- a/superscore/widgets/page/entry.py
+++ b/superscore/widgets/page/entry.py
@@ -9,12 +9,12 @@ import qtawesome as qta
 from qtpy import QtWidgets
 from qtpy.QtGui import QCloseEvent
 
-from superscore.client import Client
 from superscore.control_layers._base_shim import EpicsData
 from superscore.model import (Collection, Nestable, Parameter, Readback,
                               Setpoint, Severity, Snapshot, Status)
-from superscore.type_hints import AnyEpicsType, OpenPageSlot
-from superscore.widgets.core import DataWidget, Display, NameDescTagsWidget
+from superscore.type_hints import AnyEpicsType
+from superscore.widgets.core import (DataWidget, Display, NameDescTagsWidget,
+                                     WindowLinker)
 from superscore.widgets.manip_helpers import (insert_widget,
                                               match_line_edit_text_width)
 from superscore.widgets.thread_helpers import BusyCursorThread
@@ -25,7 +25,7 @@ from superscore.widgets.views import (LivePVTableView, NestableTableView,
 logger = logging.getLogger(__name__)
 
 
-class NestablePage(Display, DataWidget):
+class NestablePage(Display, DataWidget, WindowLinker):
     filename = 'nestable_page.ui'
 
     meta_placeholder: QtWidgets.QWidget
@@ -42,15 +42,11 @@ class NestablePage(Display, DataWidget):
         self,
         *args,
         data: Nestable,
-        client: Client,
         editable: bool = False,
-        open_page_slot: Optional[OpenPageSlot] = None,
         **kwargs
     ):
         super().__init__(*args, data=data, **kwargs)
-        self.client = client
         self.editable = editable
-        self.open_page_slot = open_page_slot
         self._last_data = deepcopy(self.data)
         self.setup_ui()
 
@@ -61,7 +57,6 @@ class NestablePage(Display, DataWidget):
         # show tree view
         self.tree_view.client = self.client
         self.tree_view.set_data(self.data)
-        self.tree_view.open_page_slot = self.open_page_slot
 
         self.sub_pv_table_view.client = self.client
         self.sub_pv_table_view.set_data(self.data)
@@ -115,7 +110,7 @@ class SnapshotPage(NestablePage):
     data: Snapshot
 
 
-class BaseParameterPage(Display, DataWidget):
+class BaseParameterPage(Display, DataWidget, WindowLinker):
     filename = 'parameter_page.ui'
 
     meta_placeholder: QtWidgets.QWidget
@@ -159,15 +154,11 @@ class BaseParameterPage(Display, DataWidget):
     def __init__(
         self,
         *args,
-        client: Client,
         editable: bool = False,
-        open_page_slot: Optional[OpenPageSlot] = None,
         **kwargs
     ):
         super().__init__(*args, **kwargs)
-        self.client = client
         self.editable = editable
-        self.open_page_slot = open_page_slot
         self.value_stored_widget = None
         self.edata = None
         self._edata_thread: Optional[BusyCursorThread] = None

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -24,9 +24,8 @@ from superscore.errors import EntryNotFoundError
 from superscore.model import (Collection, Entry, Nestable, Parameter, Readback,
                               Root, Setpoint, Severity, Snapshot, Status)
 from superscore.qt_helpers import QDataclassBridge
-from superscore.type_hints import OpenPageSlot
-from superscore.widgets import ICON_MAP
-from superscore.widgets.core import QtSingleton
+from superscore.widgets import ICON_MAP, get_window
+from superscore.widgets.core import QtSingleton, WindowLinker
 
 logger = logging.getLogger(__name__)
 
@@ -37,15 +36,15 @@ PVEntry = Union[Parameter, Setpoint, Readback]
 def add_open_page_to_menu(
     menu: QtWidgets.QMenu,
     entry: Entry,
-    open_page_slot: OpenPageSlot
 ) -> None:
+    window = get_window()
     open_action = menu.addAction(
         f'&Open Detailed {type(entry).__name__} page'
     )
     # WeakPartialMethodSlot may not be needed, menus are transient
     # TODO: refactor to not require passing open_page_slot, maybe with window
     # singleton eventually
-    open_action.triggered.connect(partial(open_page_slot, entry))
+    open_action.triggered.connect(partial(window.open_page, entry))
 
 
 # Entries for comparison
@@ -598,7 +597,7 @@ class RootTree(QtCore.QAbstractItemModel):
         self.endInsertRows()
 
 
-class RootTreeView(QtWidgets.QTreeView):
+class RootTreeView(QtWidgets.QTreeView, WindowLinker):
     """
     Tree view for displaying an Entry.
     Contains a standard context menu and action set
@@ -618,13 +617,11 @@ class RootTreeView(QtWidgets.QTreeView):
         *args,
         client: Optional[Client] = None,
         entry: Optional[Entry] = None,
-        open_page_slot: Optional[OpenPageSlot] = None,
         **kwargs,
     ):
         super().__init__(*args, **kwargs)
         self._client = client
         self.data = entry
-        self.open_page_slot = open_page_slot
 
         self.setup_ui()
 
@@ -637,12 +634,11 @@ class RootTreeView(QtWidgets.QTreeView):
         self.setExpandsOnDoubleClick(False)
         self.doubleClicked.connect(self.open_index)
 
-    @property
-    def client(self):
-        return self._client
-
-    @client.setter
+    @WindowLinker.client.setter
     def client(self, client: Client):
+        if not isinstance(client, Client):
+            raise TypeError(f"Cannot set a {type(client)} as a client")
+
         if client is self._client:
             return
 
@@ -1288,7 +1284,7 @@ class _PVPollThread(QtCore.QThread):
             time.sleep(max((0, self.poll_period - elapsed)))
 
 
-class BaseDataTableView(QtWidgets.QTableView):
+class BaseDataTableView(QtWidgets.QTableView, WindowLinker):
     """
     Base TableView for holding and manipulating an entry / list of entries
     """
@@ -1307,16 +1303,12 @@ class BaseDataTableView(QtWidgets.QTableView):
     def __init__(
         self,
         *args,
-        client: Optional[Client] = None,
         data: Optional[Union[Entry, List[Entry]]] = None,
-        open_page_slot: Optional[OpenPageSlot] = None,
         **kwargs,
     ) -> None:
         """need to set open_column, close_column in subclass"""
         super().__init__(*args, **kwargs)
         self.data = data
-        self._client = client
-        self.open_page_slot = open_page_slot
         self.sub_entries = []
         self.model_kwargs = {}
 
@@ -1398,15 +1390,14 @@ class BaseDataTableView(QtWidgets.QTableView):
         """
         raise NotImplementedError
 
-    @property
-    def client(self):
-        return self._client
-
-    @client.setter
+    @WindowLinker.client.setter
     def client(self, client: Client):
         self._set_client(client)
 
     def _set_client(self, client: Client):
+        if not isinstance(client, Client):
+            raise TypeError(f"Cannot set a {type(client)} as a client")
+
         if client is self._client:
             return
 


### PR DESCRIPTION
## Description
- Makes `Window` a `QtSingleton`, and adds an access function for use throughout superscore ui widgets
  - Uses this singleton to access methods that were passed around manually in the past as optional arguments or set attributes.  In particular
    - Open Page Slot: removed as an optional argument on all page widgets, only retrieved by the Window singleton.  (since this argument has no meaning outside the context of the full application)
    - client: Added a backup access path via `Window` singleton, but also retained the init argument.  This permits testing of widgets individually
- These methods are gathered in a `WindowLinker` mixin class for convenience and de-duplication 

I ended up treating these two differently, and am open to differing opinions here.  Perhaps I should have left the existing open_page_slot optional arguments and treated it like I did the Client

## Motivation and Context
We found that we were passing around information held by the window throughout our application.  We also find ourselves wanting to open pages from other sub-pages, not just from the main window.  

If we ever want to change the information passed from page to page, we'd end up having to change the signature of all those widgets. It's probably best to avoid this behavior

## How Has This Been Tested?
By ensuring the tests still pass.  The required arguments of the existing widgets haven't changed, in theory (as borne out by the tests)

## Where Has This Been Documented?
This PR

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
