### PR TITLE
MNT: re-create populate_backend for use in superscore demo

### DIFF
--- a/docs/source/upcoming_release_notes/119-mnt_pop_bknd.rst
+++ b/docs/source/upcoming_release_notes/119-mnt_pop_bknd.rst
@@ -1,0 +1,23 @@
+119 mnt_pop_bknd
+################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Replaces `populate_backend` to help enable `superscore demo` cli
+- Adds basic test coverage for command line interface
+
+Contributors
+------------
+- tangkong

--- a/superscore/backends/core.py
+++ b/superscore/backends/core.py
@@ -116,7 +116,7 @@ def populate_backend(backend: _Backend, sources: Iterable[Union[Callable, str, R
     * Roots
     * Entries
     * Callables that return Roots or Entries
-    * strings that search for test data callables
+    * strings that search for test data callables, but critically not fixtures
     """
     for source in sources:
         if isinstance(source, Callable):

--- a/superscore/backends/core.py
+++ b/superscore/backends/core.py
@@ -3,9 +3,10 @@ Base superscore data storage backend interface
 """
 import re
 from collections.abc import Container, Generator
-from typing import NamedTuple, Union
+from typing import Callable, Iterable, NamedTuple, Union
 from uuid import UUID
 
+import superscore.tests.conftest_data
 from superscore.model import Entry, Root
 from superscore.type_hints import AnyEpicsType
 
@@ -106,3 +107,30 @@ class _Backend:
     def root(self) -> Root:
         """Return the Root Entry in this backend"""
         raise NotImplementedError
+
+
+def populate_backend(backend: _Backend, sources: Iterable[Union[Callable, str, Root, Entry]]) -> None:
+    """
+    Utility for quickly filling test backends with data. Supports a mix of many
+    types of sources:
+    * Roots
+    * Entries
+    * Callables that return Roots or Entries
+    * strings that search for test data callables
+    """
+    for source in sources:
+        if isinstance(source, Callable):
+            data = source()
+        elif isinstance(source, str):
+            func = getattr(superscore.tests.conftest_data, source, False)
+            data = func()
+        elif isinstance(source, (Root, Entry)):
+            data = source
+        else:
+            raise ValueError(f"Unsupported source type: {type(source)}")
+
+        if isinstance(data, Root):
+            for entry in data.entries:
+                backend.save_entry(entry)
+        else:
+            backend.save_entry(data)

--- a/superscore/backends/test.py
+++ b/superscore/backends/test.py
@@ -2,10 +2,9 @@
 Backend that manipulates Entries in-memory for testing purposes.
 """
 from copy import deepcopy
-from typing import Callable, Dict, Iterable, List, Optional, Union
+from typing import Dict, List, Optional, Union
 from uuid import UUID
 
-import superscore.tests.conftest_data
 from superscore.backends.core import SearchTermType, _Backend
 from superscore.errors import (BackendError, EntryExistsError,
                                EntryNotFoundError)
@@ -100,30 +99,3 @@ class TestBackend(_Backend):
                         conditions.append(False)
             if all(conditions):
                 yield entry
-
-
-def populate_backend(backend: _Backend, sources: Iterable[Union[Callable, str, Root, Entry]]) -> None:
-    """
-    Utility for quickly filling test backends with data. Supports a mix of many
-    types of sources:
-    * Roots
-    * Entries
-    * Callables that return Roots or Entries
-    * strings that search for test data callables
-    """
-    for source in sources:
-        if isinstance(source, Callable):
-            data = source()
-        elif isinstance(source, str):
-            func = getattr(superscore.tests.conftest_data, source, False)
-            data = func()
-        elif isinstance(source, (Root, Entry)):
-            data = source
-        else:
-            raise ValueError(f"Unsupported source type: {type(source)}")
-
-        if isinstance(data, Root):
-            for entry in data.entries:
-                backend.save_entry(entry)
-        else:
-            backend.save_entry(data)

--- a/superscore/bin/__init__.py
+++ b/superscore/bin/__init__.py
@@ -1,3 +1,3 @@
-from .main import main
+from . import main
 
 __all__ = ["main"]

--- a/superscore/bin/demo.py
+++ b/superscore/bin/demo.py
@@ -9,7 +9,7 @@ import logging
 import os
 from pathlib import Path
 
-import superscore.tests.conftest
+from superscore.backends.test import populate_backend
 from superscore.bin.ui import main as ui_main
 from superscore.client import Client
 from superscore.model import Readback, Setpoint
@@ -48,7 +48,7 @@ def main(*args, db_path=None, **kwargs):
         pass
     # write data from the sources to the backend
     source_names = parser.get("demo", "fixtures").split()
-    superscore.tests.conftest.populate_backend(client.backend, source_names)
+    populate_backend(client.backend, source_names)
     # IOCFactory needs the Entries with data
     filled = [entry for entry in client.search() if isinstance(entry, (Setpoint, Readback))]
     with IOCFactory.from_entries(filled, client)(prefix=''):

--- a/superscore/bin/demo.py
+++ b/superscore/bin/demo.py
@@ -9,7 +9,7 @@ import logging
 import os
 from pathlib import Path
 
-from superscore.backends.test import populate_backend
+from superscore.backends.core import populate_backend
 from superscore.bin.ui import main as ui_main
 from superscore.client import Client
 from superscore.model import Readback, Setpoint

--- a/superscore/tests/conftest.py
+++ b/superscore/tests/conftest.py
@@ -14,7 +14,8 @@ from superscore.backends.test import TestBackend
 from superscore.client import Client
 from superscore.control_layers._base_shim import _BaseShim
 from superscore.control_layers.core import ControlLayer
-from superscore.model import Entry, Nestable, Root
+from superscore.model import (Collection, Entry, Nestable, Parameter, Root,
+                              Setpoint)
 from superscore.tests.ioc import IOCFactory
 from superscore.widgets.views import EntryItem
 from superscore.widgets.window import Window
@@ -29,6 +30,31 @@ from .conftest_data import (linac_data, linac_with_comparison_snapshot,  # NOQA
 def linac_backend():
     root = linac_data()
     return TestBackend(root.entries)
+
+
+@pytest.fixture(scope='function')
+def linac_with_comparison_snapshot_fixture() -> Root:
+    return linac_with_comparison_snapshot()
+
+
+@pytest.fixture(scope='function')
+def setpoint_with_readback_fixture() -> Setpoint:
+    return setpoint_with_readback()
+
+
+@pytest.fixture(scope='function')
+def parameter_with_readback_fixture() -> Parameter:
+    return parameter_with_readback()
+
+
+@pytest.fixture(scope='function')
+def simple_snapshot_fixture() -> Collection:
+    return simple_snapshot()
+
+
+@pytest.fixture(scope='function')
+def sample_database_fixture() -> Root:
+    return sample_database()
 
 
 class DummyShim(_BaseShim):
@@ -113,7 +139,7 @@ def test_data(request: pytest.FixtureRequest) -> Root:
     Expects `request.param` to return a dictionary with the schema:
     {
         sources: List[StringNameOfFixtureOrCallable]
-}
+    }
 
     Supports fixtures and callables that resolve to:
     * Root

--- a/superscore/tests/conftest_data.py
+++ b/superscore/tests/conftest_data.py
@@ -1,7 +1,12 @@
+"""
+Home for functions that return an Entry or Root
+
+Do not place pytest fixtures here, as these callables may be used in running
+demo instances.  Instead create corresponding fixtures in conftest.py directly
+"""
+
 from copy import deepcopy
 from uuid import UUID
-
-import pytest
 
 from superscore.model import (Collection, Parameter, Readback, Root, Setpoint,
                               Severity, Snapshot, Status)
@@ -728,7 +733,6 @@ def linac_with_comparison_snapshot() -> Root:
     return root
 
 
-@pytest.fixture(scope='function')
 def setpoint_with_readback() -> Setpoint:
     """
     A simple setpoint-readback value pair
@@ -749,7 +753,6 @@ def setpoint_with_readback() -> Setpoint:
     return setpoint
 
 
-@pytest.fixture(scope='function')
 def parameter_with_readback() -> Parameter:
     """
     A simple setpoint-readback parameter pair
@@ -768,7 +771,6 @@ def parameter_with_readback() -> Parameter:
     return setpoint
 
 
-@pytest.fixture(scope="function")
 def simple_snapshot() -> Collection:
     snap = Snapshot(description='various types', title='types collection')
     snap.children.append(Setpoint(pv_name="MY:FLOAT"))
@@ -777,7 +779,6 @@ def simple_snapshot() -> Collection:
     return snap
 
 
-@pytest.fixture(scope='function')
 def sample_database() -> Root:
     """
     A sample superscore database, including all the Entry types.

--- a/superscore/tests/test_cli.py
+++ b/superscore/tests/test_cli.py
@@ -1,0 +1,36 @@
+"""Tests for cli endpoints"""
+import sys
+
+import pytest
+
+import superscore.bin.demo as demo_main
+import superscore.bin.main as ss_main
+from superscore.tests.ioc.ioc_factory import TempIOC
+
+
+def test_cli_help(monkeypatch):
+    monkeypatch.setattr(sys, "argv", ["superscore", "demo", "--help"])
+    with pytest.raises(SystemExit):
+        ss_main.main()
+
+
+@pytest.mark.parametrize('subcommand', list(ss_main.MODULES))
+def test_help_module(monkeypatch, subcommand: str):
+    monkeypatch.setattr(sys, "argv", ["superscore", subcommand, "--help"])
+    with pytest.raises(SystemExit):
+        ss_main.main()
+
+
+def test_demo_smoke(monkeypatch):
+    """
+    This primarily tests demo backend gathering, ui component creation tested
+    elsewhere
+    """
+    def mockreturn(*args, **kwargs):
+        return
+
+    monkeypatch.setattr(sys, "argv", ["superscore", "demo"])
+    # Prevent qt components from being created, since we can't fully clean up
+    monkeypatch.setattr(demo_main, 'ui_main', mockreturn)
+    monkeypatch.setattr(TempIOC, "__enter__", mockreturn)
+    ss_main.main()

--- a/superscore/tests/test_model.py
+++ b/superscore/tests/test_model.py
@@ -40,10 +40,10 @@ def test_serialize_snapshot_roundtrip():
     assert deserialized.children[1].children[1] == v2
 
 
-def test_sample_database_roundtrip(sample_database: Root):
-    ser = apischema.serialize(Root, sample_database)
+def test_sample_database_roundtrip(sample_database_fixture: Root):
+    ser = apischema.serialize(Root, sample_database_fixture)
     deser = apischema.deserialize(Root, ser)
-    assert deser == sample_database
+    assert deser == sample_database_fixture
 
 
 class TestEntryValidation:

--- a/superscore/tests/test_page.py
+++ b/superscore/tests/test_page.py
@@ -86,8 +86,12 @@ def collection_builder_page(qtbot: QtBot, test_client: Client):
 
 
 @pytest.fixture(scope="function")
-def restore_page(qtbot: QtBot, test_client: Client, simple_snapshot: Snapshot):
-    page = RestorePage(data=simple_snapshot, client=test_client)
+def restore_page(
+    qtbot: QtBot,
+    test_client: Client,
+    simple_snapshot_fixture: Snapshot
+):
+    page = RestorePage(data=simple_snapshot_fixture, client=test_client)
     qtbot.addWidget(page)
     yield page
     page.close()
@@ -284,25 +288,28 @@ def test_restore_page_toggle_live(qtbot: QtBot, restore_page):
 @setup_test_stack(sources=["db/filestore.json"], backend_type=FilestoreBackend)
 def test_restore_dialog_restore(
     test_client: Client,
-    simple_snapshot: Snapshot,
+    simple_snapshot_fixture: Snapshot,
 ):
     put_mock = test_client.cl.put
-    dialog = RestoreDialog(test_client, simple_snapshot)
+    dialog = RestoreDialog(test_client, simple_snapshot_fixture)
     dialog.restore()
-    assert put_mock.call_args.args == test_client._gather_data(simple_snapshot)
+    assert put_mock.call_args.args == test_client._gather_data(simple_snapshot_fixture)
 
 
 @setup_test_stack(sources=["db/filestore.json"], backend_type=FilestoreBackend)
-def test_restore_dialog_remove_pv(test_client: Client, simple_snapshot: Snapshot):
-    dialog = RestoreDialog(test_client, simple_snapshot)
+def test_restore_dialog_remove_pv(
+    test_client: Client,
+    simple_snapshot_fixture: Snapshot
+):
+    dialog = RestoreDialog(test_client, simple_snapshot_fixture)
     tableWidget = dialog.tableWidget
-    assert tableWidget.rowCount() == len(simple_snapshot.children)
+    assert tableWidget.rowCount() == len(simple_snapshot_fixture.children)
 
     PV_COLUMN = 0
     REMOVE_BUTTON_COLUMN = 2
     item_to_remove = tableWidget.item(1, PV_COLUMN)
     tableWidget.setCurrentCell(1, REMOVE_BUTTON_COLUMN)
     dialog.delete_row()
-    assert tableWidget.rowCount() == len(simple_snapshot.children) - 1
+    assert tableWidget.rowCount() == len(simple_snapshot_fixture.children) - 1
     items_left = [tableWidget.item(row, PV_COLUMN) for row in range(tableWidget.rowCount())]
     assert item_to_remove not in items_left

--- a/superscore/tests/test_views.py
+++ b/superscore/tests/test_views.py
@@ -23,13 +23,13 @@ from superscore.widgets.views import (CustRoles, EntryItem, LivePVHeader,
 @pytest.fixture(scope='function')
 def pv_poll_model(
     test_client: Client,
-    parameter_with_readback: Parameter,
+    parameter_with_readback_fixture: Parameter,
     qtbot: QtBot
 ):
     """Minimal LivePVTableModel, containing only Parameters (no stored data)"""
     model = LivePVTableModel(
         client=test_client,
-        entries=[parameter_with_readback],
+        entries=[parameter_with_readback_fixture],
         poll_period=1.0
     )
 
@@ -46,7 +46,7 @@ def pv_poll_model(
 @pytest.fixture(scope="function")
 def pv_table_view(
     test_client: Client,
-    simple_snapshot: Collection,
+    simple_snapshot_fixture: Collection,
     qtbot: QtBot,
 ):
     """
@@ -70,7 +70,7 @@ def pv_table_view(
 
     view = LivePVTableView()
     view.client = test_client
-    view.set_data(simple_snapshot)
+    view.set_data(simple_snapshot_fixture)
 
     qtbot.wait_until(lambda: view.model()._poll_thread.isRunning())
     yield view
@@ -200,19 +200,19 @@ def test_stat_sev_enums(pv_table_view: LivePVTableView):
 
 def test_fill_uuids_pvs(
     test_client: Client,
-    simple_snapshot: Collection,
+    simple_snapshot_fixture: Collection,
     qtbot: QtBot,
 ):
     """Verify UUID data gets filled, and dataclass gets modified"""
-    simple_snapshot.swap_to_uuids()
-    assert all(isinstance(c, UUID) for c in simple_snapshot.children)
+    simple_snapshot_fixture.swap_to_uuids()
+    assert all(isinstance(c, UUID) for c in simple_snapshot_fixture.children)
     view = LivePVTableView()
     # mock client does not ever return None, as if entries are always found
     # in the backend
     view.client = test_client
-    view.set_data(simple_snapshot)
+    view.set_data(simple_snapshot_fixture)
 
-    assert all(not isinstance(c, UUID) for c in simple_snapshot.children)
+    assert all(not isinstance(c, UUID) for c in simple_snapshot_fixture.children)
     print(view.model()._poll_thread)
     view.model().stop_polling()
     print(view.model()._poll_thread)
@@ -272,8 +272,8 @@ def test_fill_uuids_entry_item(test_client: Client, qtbot: QtBot):
     assert root_item.child(2).child(0).childCount() == 0
 
 
-def test_roottree_setup(sample_database: Root):
-    tree_model = RootTree(base_entry=sample_database)
+def test_roottree_setup(sample_database_fixture: Root):
+    tree_model = RootTree(base_entry=sample_database_fixture)
     root_index = tree_model.index_from_item(tree_model.root_item)
     # Check that the entire tree was created
     assert tree_model.rowCount(root_index) == 4


### PR DESCRIPTION
## Description
Re-add `populate_backend` for use in `superscore demo` and other purposes

## Motivation and Context
I broke the demo command, sorry

## How Has This Been Tested?
Interactively, and some rudimentary smoke tests have been added to cover the cli

## Where Has This Been Documented?
This PR 

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
