### PR TITLE
BUG: refresh main window tree when new collection is created

### DIFF
--- a/docs/source/upcoming_release_notes/125-bug_refresh_window.rst
+++ b/docs/source/upcoming_release_notes/125-bug_refresh_window.rst
@@ -1,0 +1,22 @@
+125 bug_refresh_window
+######################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Refreshes window whenever a new collection is added from the `CollectionBuilderPage`
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/superscore/tests/test_window.py
+++ b/superscore/tests/test_window.py
@@ -5,6 +5,8 @@ from pytestqt.qtbot import QtBot
 from superscore.backends.filestore import FilestoreBackend
 from superscore.client import Client
 from superscore.tests.conftest import setup_test_stack
+from superscore.widgets.page.collection_builder import CollectionBuilderPage
+from superscore.widgets.views import EntryItem
 from superscore.widgets.window import Window
 
 
@@ -58,3 +60,23 @@ def test_sample_window(qtbot: QtBot, test_client: Client):
     while index.isValid():
         assert not isinstance(index.internalPointer()._data, UUID)
         index = window.tree_view.indexBelow(index)
+
+
+@setup_test_stack(sources=['db/filestore.json'], backend_type=FilestoreBackend)
+def test_add_collection_refresh(qtbot: QtBot, test_client: Client):
+    window = Window(client=test_client)
+    qtbot.addWidget(window)
+
+    window.open_collection_builder()
+
+    coll_builder_page = window.tab_widget.widget(1)
+    assert isinstance(coll_builder_page, CollectionBuilderPage)
+    orig_entry_item: EntryItem = window.tree_view.model().root_item
+    orig_top_level_entries = orig_entry_item.childCount()
+
+    coll_builder_page.save_collection()
+
+    new_entry_item: EntryItem = window.tree_view.model().root_item
+    new_top_level_entries = new_entry_item.childCount()
+
+    assert new_top_level_entries > orig_top_level_entries

--- a/superscore/widgets/core.py
+++ b/superscore/widgets/core.py
@@ -465,3 +465,10 @@ class WindowLinker:
         window = get_window()
         if window is not None:
             return window.open_page
+
+    def refresh_window(self):
+        """Refresh window ui elements"""
+        # tree view
+        window = get_window()
+        window.tree_view.set_data(self.client.backend.root)
+        window.tree_view.model().refresh_tree()

--- a/superscore/widgets/page/collection_builder.py
+++ b/superscore/widgets/page/collection_builder.py
@@ -121,6 +121,7 @@ class CollectionBuilderPage(Display, DataWidget, WindowLinker):
         self.data.description = self.meta_widget.desc_edit.toPlainText()
         # children should have been updated along the way
         self.client.save(self.data)
+        self.refresh_window()
         logger.info(f"Collection saved ({self.data.uuid})")
 
     def check_valid(self, entry: Entry) -> bool:

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -36,7 +36,7 @@ class Window(Display, QtWidgets.QMainWindow, metaclass=QtSingleton):
 
     action_new_coll: QtWidgets.QAction
 
-    # Diff dispatcher singleton
+    # Diff dispatcher singleton, used to notify when diffs are ready
     diff_dispatcher: DiffDispatcher = DiffDispatcher()
 
     def __init__(self, *args, client: Optional[Client] = None, **kwargs):


### PR DESCRIPTION
## Description
Refresh the main window tree view whenever a Collection is added through the Collection Builder Page

## Motivation and Context
Closes #111 

This takes advantage of the Window singleton pattern added some time ago.  Using this prevents us from having to pass specific methods/signals through to widgets.

## How Has This Been Tested?
Interactively, a simple test has been added.

## Where Has This Been Documented?
This PR 

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
