### PR TITLE
ENH: add button to take snapshots on Collection / Snapshot detail page

### DIFF
--- a/docs/source/upcoming_release_notes/128-take_snapshot_button.rst
+++ b/docs/source/upcoming_release_notes/128-take_snapshot_button.rst
@@ -1,0 +1,24 @@
+128 take snapshot button
+#################
+
+API Breaks
+----------
+- Client._build_snapshot optionally accepts an empty Snapshot to fill instead of creating a new one
+
+Features
+--------
+- add button to take new snapshots on NestablePage
+
+Bugfixes
+--------
+- _Backend.get -> _Backend.get_entry in Client._build_snapshot
+- add mandatory 3rd arg in setattr in FilestoreBackend.fill_uuids
+- store EpicsData.data as primitive type, so it displays properly when returned by a Qt model
+
+Maintenance
+-----------
+- adds WindowLinker.get_window() so WindowLinkers can do more with the Window outside of dedicated methods
+
+Contributors
+------------
+- shilorigins

--- a/superscore/backends/filestore.py
+++ b/superscore/backends/filestore.py
@@ -185,7 +185,7 @@ class FilestoreBackend(_Backend):
                 new_ref = self._entry_cache.get(field_data)
                 if new_ref:
                     new_ref = self.fill_uuids(new_ref)
-                    setattr(entry, field.name)
+                    setattr(entry, field.name, new_ref)
 
         return entry
 

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -322,6 +322,29 @@ class Client:
         else:
             return self.cl.put(pv_list, data_list)
 
+    def find_origin_collection(self, entry: Union[Collection, Snapshot]) -> Collection:
+        """
+        Return the Collection instance associated with an entry.  The entry can
+        be a Collection or Snapshot.
+
+        Raises
+        ------
+        ValueError
+            If snapshot does not record an origin collection
+        EntryNotFoundError
+            From _Backend.get_entry
+        """
+        if isinstance(entry, Collection):
+            return entry
+        elif isinstance(entry, Snapshot):
+            origin = entry.origin_collection
+            if origin is None:
+                raise ValueError(f"{entry.title} ({entry.uuid}) does not have an origin collection)")
+            elif isinstance(origin, UUID):
+                return self.backend.get_entry(origin)
+            else:
+                return origin
+
     def _gather_data(
         self,
         entry: Union[Entry, UUID],

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -422,7 +422,7 @@ class Client:
 
         for child in coll.children:
             if isinstance(child, UUID):
-                child = self.backend.get(child)
+                child = self.backend.get_entry(child)
             if isinstance(child, Parameter):
                 if child.readback is not None:
                     edata = self._value_or_default(

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -248,7 +248,7 @@ class Client:
 
             entry.children = new_children
 
-    def snap(self, entry: Collection) -> Snapshot:
+    def snap(self, entry: Collection, dest: Optional[Snapshot] = None) -> Snapshot:
         """
         Asyncronously read data for all PVs under ``entry``, and store in a
         Snapshot.  PVs that can't be read will have an exception as their value.
@@ -275,7 +275,7 @@ class Client:
             else:
                 logger.debug(f"Storing {pv} = {value}")
                 data[pv] = value
-        return self._build_snapshot(entry, data)
+        return self._build_snapshot(entry, data, dest=dest)
 
     def apply(
         self,
@@ -397,6 +397,7 @@ class Client:
         self,
         coll: Collection,
         values: Dict[str, EpicsData],
+        dest: Optional[Snapshot] = None,
     ) -> Snapshot:
         """
         Traverse a Collection, assembling a Snapshot using pre-fetched data
@@ -414,11 +415,11 @@ class Client:
         Snapshot
             A Snapshot corresponding to the input Collection
         """
-        snapshot = Snapshot(
+        snapshot = dest or Snapshot(
             title=coll.title,
             tags=coll.tags.copy(),
-            origin_collection=coll
         )
+        snapshot.origin_collection = coll
 
         for child in coll.children:
             if isinstance(child, UUID):

--- a/superscore/control_layers/_aioca.py
+++ b/superscore/control_layers/_aioca.py
@@ -113,7 +113,7 @@ class AiocaShim(_BaseShim):
         enums = getattr(value_ctrl, "enums", None)
 
         return EpicsData(
-            data=value_time,
+            data=+value_time,  # from aioca docs, +AugmentedValue strips augmentation
             status=status,
             severity=severity,
             timestamp=timestamp,

--- a/superscore/tests/conftest_data.py
+++ b/superscore/tests/conftest_data.py
@@ -632,7 +632,8 @@ def linac_data() -> Root:
             lcls_nc_snapshot,
             facet_snapshot,
             lcls_sc_snapshot,
-        ]
+        ],
+        origin_collection=all_col.uuid,
     )
 
     return Root(entries=[all_col, all_snapshot])

--- a/superscore/tests/test_window.py
+++ b/superscore/tests/test_window.py
@@ -80,3 +80,29 @@ def test_add_collection_refresh(qtbot: QtBot, test_client: Client):
     new_top_level_entries = new_entry_item.childCount()
 
     assert new_top_level_entries > orig_top_level_entries
+
+
+@setup_test_stack(sources=["db/filestore.json"], backend_type=FilestoreBackend)
+def test_take_snapshot(qtbot, test_client):
+    window = Window(client=test_client)
+    qtbot.addWidget(window)
+    collection = tuple(test_client.search(("uuid", "eq", UUID("a9f289d4-3421-4107-8e7f-2fe0daab77a5"))))[0]
+    snapshot = tuple(test_client.search(("uuid", "eq", UUID("ffd668d3-57d9-404e-8366-0778af7aee61"))))[0]
+
+    collection_page = window.open_page(collection)
+    new_snapshot = collection_page.take_snapshot()
+    collection_page.children()[-1].done(1)
+    search_result = tuple(test_client.search(("uuid", 'eq', new_snapshot.uuid)))
+    assert new_snapshot == search_result[0]
+
+    snapshot_page = window.open_page(snapshot)
+    result = snapshot_page.take_snapshot()
+    assert result is None
+    snapshot_page.close()
+
+    snapshot.origin_collection = collection.uuid
+    snapshot_page = window.open_page(snapshot)
+    new_snapshot = snapshot_page.take_snapshot()
+    snapshot_page.children()[-1].done(1)
+    search_result = tuple(test_client.search(("uuid", 'eq', new_snapshot.uuid)))
+    assert new_snapshot == search_result[0]

--- a/superscore/ui/nestable_page.ui
+++ b/superscore/ui/nestable_page.ui
@@ -13,25 +13,48 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <widget class="QWidget" name="meta_placeholder" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-    </widget>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="1,0">
+     <item>
+      <widget class="QWidget" name="meta_placeholder" native="true">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QFrame" name="frame">
+       <property name="frameShape">
+        <enum>QFrame::StyledPanel</enum>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Raised</enum>
+       </property>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="0">
+         <widget class="QPushButton" name="snapshot_button">
+          <property name="text">
+           <string>PushButton</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
    </item>
-   <item>
+   <item row="1" column="0">
     <widget class="Line" name="line">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
-   <item>
+   <item row="2" column="0">
     <widget class="QSplitter" name="splitter_2">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -65,7 +88,7 @@
      </widget>
     </widget>
    </item>
-   <item>
+   <item row="3" column="0">
     <widget class="QPushButton" name="save_button">
      <property name="text">
       <string>Save</string>

--- a/superscore/widgets/core.py
+++ b/superscore/widgets/core.py
@@ -466,6 +466,10 @@ class WindowLinker:
         if window is not None:
             return window.open_page
 
+    def get_window(self):
+        """Return the singleton Window instance"""
+        return get_window()
+
     def refresh_window(self):
         """Refresh window ui elements"""
         # tree view


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
* fix bug where `Client._build_snapshot` calls `_Backend.get`, which doesn't exist
* fix bug where `FilestoreBackend.fill_uuids` calls `setattr` with only two args
  * closes #126 
* strip `AugmentedValue` metadata when setting `EpicsData.data` in `_AoicaShim`
  * this was causing a bug where returning `EpicsData.data` from a view's `.data` method caused the cells to show as empty
* add button on `nestable_page.ui` (used for showing details of `Collection`s and `Snapshot`s) that takes a new snapshot for the associated `Collection`
  * closes #50 
* include dialog for setting metadata for new snapshot
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Taking new snapshots is a core feature of the app.  The button is placed on the detailed nestables page so that it's available for `Collection`s and `Snapshot`s.

The dialog uses a `NameDescTagsWidget`, which requires attaching a `Snapshot` to leverage the existing functionality.  Since `Client._build_snapshot` creates a new `Snapshot` and then builds its structure using the origin `Collection` for reference, passing the newly made `Snapshot` through to `Client._build_snapshot` saves some arg checks and redundant variable assignments.

`Client.snap` first fetches values for all of the PVs, then creates and builds the new `Snapshot`, so the app currently hangs while values are being collected rather than opening the snapshot table and filling in the cells as values arrive.  Since I would have to refactor `Client.snap` / `._build_snapshot` to achieve the latter behaviour, I've omitted it from this Pr.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
New test (in `test_window.py` since it requires inspecting the tab widget and tree view).

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
This PR
<!--
## Screenshots (if appropriate):
-->

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate