### PR TITLE
ENH: Add meta PVs to top-level entries in demo dataset and implement table to present them.

### DIFF
--- a/.github/workflows/standard.yml
+++ b/.github/workflows/standard.yml
@@ -1,7 +1,6 @@
 name: PCDS Standard Testing
 
 on:
-  push:
   pull_request:
   release:
     types:

--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,5 @@ Thumbs.db
 
 # setuptools-scm _version.py should not be tracked:
 /superscore/_version.py
+
+.vscode/*

--- a/superscore/tests/conftest_data.py
+++ b/superscore/tests/conftest_data.py
@@ -302,6 +302,14 @@ def linac_data() -> Root:
         ]
     )
 
+    all_col_beam_e_meta_pv = Parameter(
+        uuid="e4aa8dc8-dbb0-4331-999a-89053758d489",
+        pv_name="BEAME",
+        description="A beam energy PV",
+    )
+
+    all_col.meta_pvs.append(all_col_beam_e_meta_pv)
+
     lasr_gunb_value1 = Setpoint(
         uuid="927ef6cb-e45f-4175-aa5f-6c6eec1f3ae4",
         pv_name=lasr_gunb_pv1.pv_name,
@@ -624,6 +632,12 @@ def linac_data() -> Root:
         ]
     )
 
+    all_snapshot_beam_e_meta_pv = Readback(
+        uuid="e8af7485-9c62-45c7-9c50-94cbe83c38b0",
+        pv_name="BEAME",
+        description="A beam energy readback PV",
+    )
+
     all_snapshot = Snapshot(
         uuid="06282731-33ea-4270-ba14-098872e627dc",
         description=all_col.description,
@@ -634,6 +648,7 @@ def linac_data() -> Root:
             lcls_sc_snapshot,
         ],
         origin_collection=all_col.uuid,
+        meta_pvs=[all_snapshot_beam_e_meta_pv],
     )
 
     return Root(entries=[all_col, all_snapshot])


### PR DESCRIPTION
## Description

- Add `.vscode` directory to gitignore
- Add a `Parameter` and `Readback` representing some beam energy PV, and it to the top level collection and snapshot, respectively.
- Fit tab group into existing layout, allowing for switching between live 'content' PVs and meta PVs (label text tentative)
- Implement `LiveMetaPVTableView`, which is derived from `LivePVTableView`, but looks at data from `self.data.meta_pvs`

![image](https://github.com/user-attachments/assets/07382c04-bc49-477f-ae52-1bab73a81faf)


## Motivation and Context
Adding meta pvs to the demo dataset will help demonstrate that functionality.
Resolves #120 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?

This PR

## Pre-merge checklist

- [ ] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
