### PR TITLE
ENH: Group related setpoint-readback pairs in LivePVTableView

### DIFF
--- a/docs/source/upcoming_release_notes/125-bug_refresh_window.rst
+++ b/docs/source/upcoming_release_notes/125-bug_refresh_window.rst
@@ -1,0 +1,22 @@
+125 bug_refresh_window
+######################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Refreshes window whenever a new collection is added from the `CollectionBuilderPage`
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/superscore/tests/test_window.py
+++ b/superscore/tests/test_window.py
@@ -5,6 +5,8 @@ from pytestqt.qtbot import QtBot
 from superscore.backends.filestore import FilestoreBackend
 from superscore.client import Client
 from superscore.tests.conftest import setup_test_stack
+from superscore.widgets.page.collection_builder import CollectionBuilderPage
+from superscore.widgets.views import EntryItem
 from superscore.widgets.window import Window
 
 
@@ -58,3 +60,23 @@ def test_sample_window(qtbot: QtBot, test_client: Client):
     while index.isValid():
         assert not isinstance(index.internalPointer()._data, UUID)
         index = window.tree_view.indexBelow(index)
+
+
+@setup_test_stack(sources=['db/filestore.json'], backend_type=FilestoreBackend)
+def test_add_collection_refresh(qtbot: QtBot, test_client: Client):
+    window = Window(client=test_client)
+    qtbot.addWidget(window)
+
+    window.open_collection_builder()
+
+    coll_builder_page = window.tab_widget.widget(1)
+    assert isinstance(coll_builder_page, CollectionBuilderPage)
+    orig_entry_item: EntryItem = window.tree_view.model().root_item
+    orig_top_level_entries = orig_entry_item.childCount()
+
+    coll_builder_page.save_collection()
+
+    new_entry_item: EntryItem = window.tree_view.model().root_item
+    new_top_level_entries = new_entry_item.childCount()
+
+    assert new_top_level_entries > orig_top_level_entries

--- a/superscore/widgets/core.py
+++ b/superscore/widgets/core.py
@@ -465,3 +465,10 @@ class WindowLinker:
         window = get_window()
         if window is not None:
             return window.open_page
+
+    def refresh_window(self):
+        """Refresh window ui elements"""
+        # tree view
+        window = get_window()
+        window.tree_view.set_data(self.client.backend.root)
+        window.tree_view.model().refresh_tree()

--- a/superscore/widgets/page/collection_builder.py
+++ b/superscore/widgets/page/collection_builder.py
@@ -121,6 +121,7 @@ class CollectionBuilderPage(Display, DataWidget, WindowLinker):
         self.data.description = self.meta_widget.desc_edit.toPlainText()
         # children should have been updated along the way
         self.client.save(self.data)
+        self.refresh_window()
         logger.info(f"Collection saved ({self.data.uuid})")
 
     def check_valid(self, entry: Entry) -> bool:

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -900,6 +900,7 @@ class LivePVTableModel(BaseTableEntryModel):
     # shows live details (current PV status, severity)
     # shows setpoints (can be blank)
     headers: List[str]
+    entries: List[PVEntry]
     _data_cache: Dict[str, EpicsData]
     _poll_thread: Optional[_PVPollThread]
     _button_cols: List[LivePVHeader] = [LivePVHeader.OPEN, LivePVHeader.REMOVE]
@@ -919,6 +920,7 @@ class LivePVTableModel(BaseTableEntryModel):
         **kwargs
     ) -> None:
         super().__init__(*args, entries=entries, **kwargs)
+        self._selected_entry: Optional[PVEntry] = None
         self.header_enum = LivePVHeader
         self.headers = [h.header_name() for h in LivePVHeader]
 
@@ -931,7 +933,12 @@ class LivePVTableModel(BaseTableEntryModel):
         self._data_cache = {e.pv_name: None for e in entries}
         self._poll_thread = None
 
+        self._linked_readbacks: list[Readback] = []
+
         self.start_polling()
+
+        # set entries again to process readbacks properly
+        self.set_entries(entries)
 
     def start_polling(self) -> None:
         """Start the polling thread"""
@@ -1002,9 +1009,40 @@ class LivePVTableModel(BaseTableEntryModel):
             )
 
     def set_entries(self, entries: list[PVEntry]) -> None:
-        """Set the entries for this table, reset data cache"""
+        """
+        Set the entries for this table, make readback links, reset data cache
+        """
         self.layoutAboutToBeChanged.emit()
-        self.entries = entries
+        # Organize setpoint/readback links
+        new_entries = []
+        skipped_readbacks = []
+        self._linked_readbacks = []
+        for entry in entries:
+            # We may have already added a readback
+            if entry in new_entries:
+                continue
+
+            if (
+                isinstance(entry, Setpoint)
+                and entry.readback is not None
+                and entry.readback in entries
+            ):
+                new_entries.append(entry)
+                # Add readback right after
+                new_entries.append(entry.readback)
+                self._linked_readbacks.append(entry.readback)
+            elif isinstance(entry, Readback):
+                # skip adding and add them to readbacks
+                skipped_readbacks.append(entry)
+            else:
+                new_entries.append(entry)
+
+        for rbv in skipped_readbacks:
+            if rbv not in new_entries:
+                new_entries.append(rbv)
+
+        self.entries = new_entries
+
         self._data_cache = {e.pv_name: None for e in entries}
         self._poll_thread.data = self._data_cache
         self.dataChanged.emit(
@@ -1078,11 +1116,29 @@ class LivePVTableModel(BaseTableEntryModel):
         if index.column() == LivePVHeader.PV_NAME:
             if role == QtCore.Qt.DecorationRole:
                 return self.icon(entry)
-            elif role in (QtCore.Qt.DisplayRole, QtCore.Qt.EditRole):
-                name_text = getattr(entry, 'pv_name')
-                return name_text
             elif role == CustRoles.DisplayTypeRole:
                 return DisplayType.PV_NAME
+
+            name_text = getattr(entry, 'pv_name')
+            if role == QtCore.Qt.DisplayRole:
+                if entry in self._linked_readbacks:
+                    name_text = "↳" + name_text
+                return name_text
+            elif role == QtCore.Qt.EditRole:
+                # make sure we don't carry vanity return character
+                return name_text
+
+        if role == QtCore.Qt.BackgroundColorRole and index.column() != LivePVHeader.LIVE_VALUE:
+            # highlight current row and linked row rbv pairing exists
+            if (
+                entry == self.selected_entry
+                or (isinstance(self.selected_entry, Setpoint)
+                    and self.selected_entry.readback is entry)
+                or (isinstance(entry, Setpoint)
+                    and self.selected_entry in self._linked_readbacks
+                    and entry.readback is self.selected_entry)
+            ):
+                return QtGui.QColor(59, 134, 255, 30)
 
         if role not in (QtCore.Qt.DisplayRole, QtCore.Qt.EditRole,
                         QtCore.Qt.BackgroundRole, CustRoles.DisplayTypeRole,
@@ -1204,6 +1260,19 @@ class LivePVTableModel(BaseTableEntryModel):
             return "fetching..."
         else:
             return data
+
+    @property
+    def selected_entry(self):
+        return self._selected_entry
+
+    @selected_entry.setter
+    def selected_entry(self, value: Entry):
+        self._selected_entry = value
+
+    def update_selected(self, index: QtCore.QModelIndex):
+        self.layoutAboutToBeChanged.emit()
+        self._selected_entry = self.entries[index.row()]
+        self.layoutChanged.emit()
 
 
 class _PVPollThread(QtCore.QThread):
@@ -1522,6 +1591,22 @@ class LivePVTableView(BaseDataTableView):
             self._model.stop_polling()
             self._model.client = self._client
             self._model.start_polling()
+
+    def maybe_setup_model(self):
+        super().maybe_setup_model()
+        sel_model = self.selectionModel()
+        # Selection model only exists if model is set
+        if sel_model:
+            # Look for "current" index, which has keyboard focus.
+            # "Selection" is not updated unless... other settings are changed
+            sel_model.currentChanged.connect(self.selection_update_slot)
+
+    def selection_update_slot(
+        self,
+        selected: QtCore.QModelIndex,
+        deselected: QtCore.QModelIndex,
+    ) -> None:
+        self._model.update_selected(selected)
 
     def closeEvent(self, a0: QtGui.QCloseEvent) -> None:
         logger.debug("Stopping pv_model polling")

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -36,7 +36,7 @@ class Window(Display, QtWidgets.QMainWindow, metaclass=QtSingleton):
 
     action_new_coll: QtWidgets.QAction
 
-    # Diff dispatcher singleton
+    # Diff dispatcher singleton, used to notify when diffs are ready
     diff_dispatcher: DiffDispatcher = DiffDispatcher()
 
     def __init__(self, *args, client: Optional[Client] = None, **kwargs):


### PR DESCRIPTION
## Description
- Groups Setpoint and Readback pairs in LivePVTableView
- Adds row highlighting that also highlights linked pairs of Entries

## Motivation and Context
#76 needs to be closed it's been around too long

## How Has This Been Tested?
Interactively, and I didn't break any tests yet. 

More tests to come soon(tm)

## Where Has This Been Documented?
This PR

<img width="689" alt="image" src="https://github.com/user-attachments/assets/1988dce6-7648-4933-971d-737403e2a491" />


## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
