### PR TITLE
BUG: fix incorrect arguments to WindowLinker.open_page_slot

### DIFF
--- a/docs/source/upcoming_release_notes/131-bug_open_page_menu_args.rst
+++ b/docs/source/upcoming_release_notes/131-bug_open_page_menu_args.rst
@@ -1,0 +1,22 @@
+131 bug_open_page_menu_args
+###########################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- N/A
+
+Bugfixes
+--------
+- Fixes incorrect argument specification in open_page_slot
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/superscore/widgets/page/search.py
+++ b/superscore/widgets/page/search.py
@@ -10,8 +10,7 @@ from qtpy import QtCore, QtWidgets
 
 from superscore.backends.core import SearchTerm
 from superscore.model import Collection, Entry, Readback, Setpoint, Snapshot
-from superscore.type_hints import OpenPageSlot
-from superscore.widgets import ICON_MAP, get_window
+from superscore.widgets import ICON_MAP
 from superscore.widgets.core import Display, WindowLinker
 from superscore.widgets.views import (BaseTableEntryModel, ButtonDelegate,
                                       HeaderEnum)
@@ -218,7 +217,7 @@ class ResultModel(BaseTableEntryModel):
         return QtCore.QVariant()
 
 
-class ResultFilterProxyModel(QtCore.QSortFilterProxyModel):
+class ResultFilterProxyModel(QtCore.QSortFilterProxyModel, WindowLinker):
     """
     Filter proxy model specifically for ResultModel.  Enables per-column sorting
     and filtering table contents by name.
@@ -234,12 +233,6 @@ class ResultFilterProxyModel(QtCore.QSortFilterProxyModel):
     ) -> None:
         super().__init__(*args, **kwargs)
         self.name_regexp = QtCore.QRegularExpression()
-
-    @property
-    def open_page_slot(self) -> Optional[OpenPageSlot]:
-        window = get_window()
-        if window is not None:
-            return window.open_page
 
     def filterAcceptsRow(
         self,

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -41,9 +41,7 @@ def add_open_page_to_menu(
     open_action = menu.addAction(
         f'&Open Detailed {type(entry).__name__} page'
     )
-    # WeakPartialMethodSlot may not be needed, menus are transient
-    # TODO: refactor to not require passing open_page_slot, maybe with window
-    # singleton eventually
+    # WeakPartialMethodSlot may not be needed, menus are transients
     open_action.triggered.connect(partial(window.open_page, entry))
 
 
@@ -694,8 +692,9 @@ class RootTreeView(QtWidgets.QTreeView, WindowLinker):
         """
         menu = QtWidgets.QMenu(self)
 
+        # checking if window exists to attach open_page_slot to
         if self.context_menu_options[MenuOption.OPEN_PAGE] and self.open_page_slot:
-            MENU_OPT_ADDER_MAP[MenuOption.OPEN_PAGE](menu, entry, self.open_page_slot)
+            MENU_OPT_ADDER_MAP[MenuOption.OPEN_PAGE](menu, entry)
 
         menu.addSeparator()
 
@@ -1447,7 +1446,7 @@ class BaseDataTableView(QtWidgets.QTableView, WindowLinker):
         """
         menu = QtWidgets.QMenu(self)
         if self.context_menu_options[MenuOption.OPEN_PAGE] and self.open_page_slot:
-            MENU_OPT_ADDER_MAP[MenuOption.OPEN_PAGE](menu, entry, self.open_page_slot)
+            MENU_OPT_ADDER_MAP[MenuOption.OPEN_PAGE](menu, entry)
 
         menu.addSeparator()
 

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -38,6 +38,9 @@ def add_open_page_to_menu(
     entry: Entry,
 ) -> None:
     window = get_window()
+    if window is None:
+        logger.debug("No window instance found")
+        return
     open_action = menu.addAction(
         f'&Open Detailed {type(entry).__name__} page'
     )
@@ -693,7 +696,7 @@ class RootTreeView(QtWidgets.QTreeView, WindowLinker):
         menu = QtWidgets.QMenu(self)
 
         # checking if window exists to attach open_page_slot to
-        if self.context_menu_options[MenuOption.OPEN_PAGE] and self.open_page_slot:
+        if self.context_menu_options[MenuOption.OPEN_PAGE]:
             MENU_OPT_ADDER_MAP[MenuOption.OPEN_PAGE](menu, entry)
 
         menu.addSeparator()
@@ -1445,7 +1448,7 @@ class BaseDataTableView(QtWidgets.QTableView, WindowLinker):
         Overload/replace this method if you would like to change this behavior
         """
         menu = QtWidgets.QMenu(self)
-        if self.context_menu_options[MenuOption.OPEN_PAGE] and self.open_page_slot:
+        if self.context_menu_options[MenuOption.OPEN_PAGE]:
             MENU_OPT_ADDER_MAP[MenuOption.OPEN_PAGE](menu, entry)
 
         menu.addSeparator()


### PR DESCRIPTION
## Description
- Fixes incorrect arguments to open_page_slot, which I missed when transitioning to use `WindowLinker`
- Also adjusts ResultFilterProxyModel to make a call to the `WindowLinker` method instead of calling `get_window ` itself.

## Motivation and Context
I got embarrassed by this bug during the standup and figured I should fix it

## How Has This Been Tested?
Interactively.  I'm going to skip writing a test for this one because triggering a context menu programmatically would involve too much hard coded position wrangling.  Maybe I revisit it later...


## Where Has This Been Documented?
This PR

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
