### PR TITLE
ENH: Add snapshot comparison to Restore page

### DIFF
--- a/superscore/ui/restore_page.ui
+++ b/superscore/ui/restore_page.ui
@@ -31,11 +31,38 @@
      <property name="frameShadow">
       <enum>QFrame::Raised</enum>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0,0,0,0,0,0">
+     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0,0,0,0,0,0,0">
       <item row="0" column="6">
        <widget class="QPushButton" name="compareSnapshotButton">
         <property name="text">
          <string>Compare to Snapshot</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="5">
+       <widget class="LiveButton" name="compareLiveButton">
+        <property name="text">
+         <string>Compare to Live</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="4">
+       <spacer name="headerSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="8">
+       <widget class="QPushButton" name="restoreButton">
+        <property name="text">
+         <string>Restore</string>
         </property>
        </widget>
       </item>
@@ -71,30 +98,10 @@
         </item>
        </layout>
       </item>
-      <item row="0" column="5">
-       <widget class="LiveButton" name="compareLiveButton">
-        <property name="text">
-         <string>Compare to Live</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="4">
-       <spacer name="headerSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
       <item row="0" column="7">
-       <widget class="QPushButton" name="restoreButton">
+       <widget class="QPushButton" name="removeComparisonButton">
         <property name="text">
-         <string>Restore</string>
+         <string>Remove Comparison</string>
         </property>
        </widget>
       </item>

--- a/superscore/ui/restore_page.ui
+++ b/superscore/ui/restore_page.ui
@@ -14,7 +14,16 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
-   <item row="0" column="0">
+   <property name="horizontalSpacing">
+    <number>0</number>
+   </property>
+   <item row="1" column="0">
+    <widget class="SnapshotTableView" name="tableView"/>
+   </item>
+   <item row="1" column="1">
+    <widget class="CompareSnapshotTableView" name="compareTableView"/>
+   </item>
+   <item row="0" column="0" colspan="2">
     <widget class="QFrame" name="headerFrame">
      <property name="frameShape">
       <enum>QFrame::StyledPanel</enum>
@@ -92,9 +101,6 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="SnapshotTableView" name="tableView"/>
-   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -107,6 +113,11 @@
    <class>LiveButton</class>
    <extends>QPushButton</extends>
    <header location="global">superscore.widgets.page.restore</header>
+  </customwidget>
+  <customwidget>
+   <class>CompareSnapshotTableView</class>
+   <extends>QTableView</extends>
+   <header>superscore.widgets.page.restore</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/superscore/widgets/page/restore.py
+++ b/superscore/widgets/page/restore.py
@@ -2,9 +2,10 @@
 
 import logging
 from enum import auto
+from typing import List, Union
 from functools import partial
 
-from qtpy import QtCore, QtWidgets
+from qtpy import QtCore, QtWidgets, QtGui
 from qtpy.QtGui import QCloseEvent
 
 from superscore.client import Client
@@ -199,6 +200,10 @@ class CompareSnapshotTableModel(QtCore.QAbstractTableModel):
                     return None
                 case CompareHeader.SECONDARY_OPEN:
                     return None
+        elif role == QtCore.Qt.BackgroundRole:
+            primary, secondary = self.entries[index.row()]
+            if self.is_secondary_column(index) and not self.is_close(primary, secondary):
+                return QtGui.QColor('#ffbbbb')
         else:
             return None
 
@@ -223,6 +228,22 @@ class CompareSnapshotTableModel(QtCore.QAbstractTableModel):
 
         if orientation == QtCore.Qt.Horizontal:
             return self.headers[section]
+
+    def is_primary_column(self, index: Union[int, QtCore.QModelIndex]):
+        if isinstance(index, QtCore.QModelIndex):
+            index = index.column()
+        hdr = self.headers[index]
+        return hdr.startswith("Primary")
+
+    def is_secondary_column(self, index: Union[int, QtCore.QModelIndex]):
+        if isinstance(index, QtCore.QModelIndex):
+            index = index.column()
+        hdr = self.headers[index]
+        return hdr.startswith("Secondary")
+
+    def is_close(self, primary: Entry, secondary: Entry):
+        # TODO: Fix this check
+        return primary == secondary
 
     @QtCore.Slot()
     def set_comparison_snapshot(self, comparison_snapshot: Snapshot) -> None:

--- a/superscore/widgets/page/restore.py
+++ b/superscore/widgets/page/restore.py
@@ -176,13 +176,26 @@ class CompareSnapshotTableModel(QtCore.QAbstractTableModel):
             return QtCore.QVariant()
 
     def rowCount(self):
-        pass
+        return len(self.entries)
 
     def columnCount(self):
-        pass
+        return len(self.headers)
 
-    def headerData(self):
-        pass
+    def headerData(
+        self,
+        section: int,
+        orientation: QtCore.Qt.Orientation,
+        role: QtCore.Qt.ItemDataRole = QtCore.Qt.DisplayRole
+    ) -> str:
+        """
+        Returns the header data for the model.
+        Currently only displays horizontal header data
+        """
+        if role != QtCore.Qt.DisplayRole:
+            return
+
+        if orientation == QtCore.Qt.Horizontal:
+            return self.headers[section]
 
     @QtCore.Slot()
     def set_comparison_snapshot(self, comparison_snapshot: Snapshot) -> None:

--- a/superscore/widgets/page/restore.py
+++ b/superscore/widgets/page/restore.py
@@ -169,11 +169,11 @@ class CompareSnapshotTableModel(QtCore.QAbstractTableModel):
                 case CompareHeader.SECONDARY_TIMESTAMP:
                     return secondary.creation_time
                 case CompareHeader.PRIMARY_OPEN:
-                    return QtCore.QVariant()
+                    return None
                 case CompareHeader.SECONDARY_OPEN:
-                    return QtCore.QVariant()
+                    return None
         else:
-            return QtCore.QVariant()
+            return None
 
     def rowCount(self):
         return len(self.entries)

--- a/superscore/widgets/page/restore.py
+++ b/superscore/widgets/page/restore.py
@@ -105,9 +105,19 @@ class RestoreDialog(Display, QtWidgets.QWidget):
 
 
 class CompareHeader(HeaderEnum):
-    COMPARISON_VALUE = auto()
-    COMPARISON_TIMESTAMP = auto()
-    COMPARISON_OPEN = auto()
+    PV_NAME = 0
+    PRIMARY_VALUE = auto()
+    SECONDARY_VALUE = auto()
+    PRIMARY_TIMESTAMP = auto()
+    SECONDARY_TIMESTAMP = auto()
+    # TODO: Find another way to represent status and severity
+    #   Potentially as a border color or icon
+    PRIMARY_STATUS = auto()
+    SECONDARY_STATUS = auto()
+    PRIMARY_SEVERITY = auto()
+    SECONDARY_SEVERITY = auto()
+    PRIMARY_OPEN = auto()
+    SECONDARY_OPEN = auto()
 
 
 class CompareSnapshotTableModel(QtCore.QAbstractTableModel):
@@ -121,7 +131,7 @@ class CompareSnapshotTableModel(QtCore.QAbstractTableModel):
         **kwargs
     ):
         super().__init__(*args, **kwargs)
-        self.headers = [h.header_name() for header in (LivePVHeader, CompareHeader) for h in header]
+        self.headers = [h.header_name() for h in CompareHeader]
         self.client = client
         self._primary_data = primary_snapshot
         self._secondary_data = comparison_snapshot
@@ -168,6 +178,14 @@ class CompareSnapshotTableModel(QtCore.QAbstractTableModel):
                     return primary.creation_time
                 case CompareHeader.SECONDARY_TIMESTAMP:
                     return secondary.creation_time
+                case CompareHeader.PRIMARY_STATUS:
+                    return primary.status
+                case CompareHeader.SECONDARY_STATUS:
+                    return secondary.status
+                case CompareHeader.PRIMARY_SEVERITY:
+                    return primary.severity
+                case CompareHeader.SECONDARY_SEVERITY:
+                    return secondary.severity
                 case CompareHeader.PRIMARY_OPEN:
                     return None
                 case CompareHeader.SECONDARY_OPEN:

--- a/superscore/widgets/page/restore.py
+++ b/superscore/widgets/page/restore.py
@@ -8,7 +8,8 @@ from qtpy import QtCore, QtWidgets
 from qtpy.QtGui import QCloseEvent
 
 from superscore.client import Client
-from superscore.model import Setpoint, Snapshot
+from superscore.model import Entry, Setpoint, Snapshot
+from superscore.compare import EntryDiff
 from superscore.widgets.core import Display
 from superscore.widgets.views import (BaseDataTableView, HeaderEnum,
                                       LivePVHeader, LivePVTableModel,
@@ -135,7 +136,8 @@ class CompareSnapshotTableModel(QtCore.QAbstractTableModel):
         self.client = client
         self._primary_data = primary_snapshot
         self._secondary_data = comparison_snapshot
-        self.entries = []
+        self.entries: List[Entry] = []
+        self.diffs: List[EntryDiff] = []
 
     def _collate_pvs(self) -> None:
         self.entries = []
@@ -161,6 +163,13 @@ class CompareSnapshotTableModel(QtCore.QAbstractTableModel):
         for secondary in pvs:
             if secondary.uuid not in seen:
                 self.entries.append((None, secondary))
+
+    def _collate_diffs(self) -> None:
+        self.diffs = []
+
+        for l_entry, r_entry in self.entries:
+
+            self.diffs.append(self.client.compare(l_entry, r_entry))
 
     def data(self, index: QtCore.QModelIndex, role: int):
         if role == QtCore.Qt.TextAlignmentRole:

--- a/superscore/widgets/page/restore.py
+++ b/superscore/widgets/page/restore.py
@@ -2,21 +2,19 @@
 
 import logging
 from enum import auto
-from typing import List, Union, Optional, Dict
 from functools import partial
+from typing import Dict, List, Optional, Union
 
-from qtpy import QtCore, QtWidgets, QtGui
+from qtpy import QtCore, QtGui, QtWidgets
 from qtpy.QtGui import QCloseEvent
 
 from superscore.client import Client
-from superscore.errors import EntryNotFoundError
-from superscore.model import Entry, Setpoint, Snapshot, UUID, Nestable, Readback
-from superscore.compare import EntryDiff
+from superscore.model import Entry, Readback, Setpoint, Snapshot
 from superscore.widgets.core import Display
-from superscore.widgets.views import (BaseDataTableView, HeaderEnum,
-                                      LivePVHeader, LivePVTableModel,
-                                      LivePVTableView, RootTree, ButtonDelegate, BaseTableEntryModel)
-from superscore.widgets.page.diff import DiffTableModel
+from superscore.widgets.views import (BaseDataTableView, BaseTableEntryModel,
+                                      HeaderEnum, LivePVHeader,
+                                      LivePVTableModel, LivePVTableView,
+                                      RootTree)
 
 logger = logging.getLogger(__name__)
 
@@ -161,6 +159,7 @@ class CompareHeader(HeaderEnum):
     COMPARE_STATUS = auto()
     SEVERITY = auto()
     COMPARE_SEVERITY = auto()
+
 
 class CompareSnapshotTableModel(BaseTableEntryModel):
     _diff_color = QtGui.QColor('#ffbbbb')
@@ -327,7 +326,7 @@ class CompareSnapshotTableView(BaseDataTableView):
             self.maybe_setup_model()
         try:
             self._model.set_comparison_snapshot(secondary)
-        except AttributeError as e:
+        except AttributeError:
             logger.debug(f"{self._model_cls} cannot be initialized")
 
     def maybe_setup_model(self):

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -1084,6 +1084,14 @@ class LivePVTableModel(BaseTableEntryModel):
             elif role == CustRoles.DisplayTypeRole:
                 return DisplayType.PV_NAME
 
+        if role == QtCore.Qt.ToolTipRole and index.column() == LivePVHeader.PV_NAME:
+            tooltip = entry.pv_name
+            if entry.severity is not Severity.NO_ALARM:
+                tooltip += f'\n{entry.severity.name}'
+            if entry.status is not Status.NO_ALARM:
+                tooltip += f'\n{entry.status.name}'
+            return tooltip
+
         if role not in (QtCore.Qt.DisplayRole, QtCore.Qt.EditRole,
                         QtCore.Qt.BackgroundRole, CustRoles.DisplayTypeRole,
                         CustRoles.EpicsDataRole):

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -167,6 +167,9 @@ class Window(Display, QtWidgets.QMainWindow, metaclass=QtSingleton):
             restore_page_action = menu.addAction('Inspect values')
             restore_page_action.triggered.connect(partial(self.open_restore_page, entry))
 
+            if self.tab_widget.currentWidget():
+                # compare selected to current
+                pass
         return menu
 
     def closeEvent(self, a0: QCloseEvent) -> None:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Adding a way to compare 2 snapshots to the Restore page (widgets/page/restore.py). The button marked "Compare to Snapshot" will open a dialog that displays the Root Tree from the left side of the screen.
When a user picks a Snapshot, the restore page will display a table with columns displaying data for each snapshot. Values that differ in the compared Snapshot will be highlighted in red.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Requested in issue #48

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Interactively

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
This PR and added docstrings

<!--
## Screenshots (if appropriate):
-->
![Screenshot 2025-03-21 at 11 32 08](https://github.com/user-attachments/assets/819ce971-2367-494b-9e52-5a80e44cedba)
![Screenshot 2025-03-21 at 11 32 12](https://github.com/user-attachments/assets/492b8127-5eb7-4d32-805f-4114f43bc9d2)



## Pre-merge checklist

- [ ] Code works interactively
- [ ] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [ ] Code contains descriptive docstrings, including context and API
- [ ] New/changed functions and methods are covered in the test suite where possible
- [ ] Test suite passes locally
- [ ] Test suite passes on GitHub Actions
- [ ] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [ ] Pre-release docs include context, functional descriptions, and contributors as appropriate
