### PR TITLE
ENH: import / export functionality

### DIFF
--- a/docs/source/upcoming_release_notes/152-enh_txt_imexport.rst
+++ b/docs/source/upcoming_release_notes/152-enh_txt_imexport.rst
@@ -1,0 +1,22 @@
+152 enh_txt_imexport
+####################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Adds ability to import/export from serialized json
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- Refactors validation methods to pass a ValidationResult (holding validation state and reasoning) instead of simple boolean
+
+Contributors
+------------
+- tangkong

--- a/docs/source/upcoming_release_notes/152-enh_txt_imexport.rst
+++ b/docs/source/upcoming_release_notes/152-enh_txt_imexport.rst
@@ -8,14 +8,17 @@ API Breaks
 Features
 --------
 - Adds ability to import/export from serialized json
+- Enable/disable Entry page save button based on Validation status, providing helpful tooltips
 
 Bugfixes
 --------
-- N/A
+- Assign readback dataclasses based on parent class.  Previously `ParameterPage` was
+  assigning a `Readback` to `Parameter.readback` instead of a `Parameter` as defined in the data model
 
 Maintenance
 -----------
 - Refactors validation methods to pass a ValidationResult (holding validation state and reasoning) instead of simple boolean
+- Allow `Window.open_page` to open uuids that exist in the database
 
 Contributors
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,4 +52,5 @@ file = "dev-requirements.txt"
 file = "docs-requirements.txt"
 
 [tool.pytest.ini_options]
-addopts = "--cov=. --no-cov-on-fail --asyncio-mode=auto"
+addopts = "--cov=. --no-cov-on-fail"
+asyncio_mode = "auto"

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -21,6 +21,7 @@ from superscore.model import (Collection, Entry, Nestable, Parameter, Readback,
 from superscore.templates import (TemplateMode, fill_template_collection,
                                   find_placeholders)
 from superscore.utils import build_abs_path, utcnow
+from superscore.validation import ValidationCode, ValidationResult
 
 logger = logging.getLogger(__name__)
 
@@ -717,7 +718,7 @@ class Client:
         sub_filled.creation_time = utcnow()
         return sub_filled
 
-    def validate(self, entry: Entry) -> bool:
+    def validate(self, entry: Entry) -> ValidationResult:
         """
         Validate ``entry`` is properly formed and able to be inserted into
         the backend.  Verifies the following in addition to the base model
@@ -727,13 +728,18 @@ class Client:
         """
         # Check for remaining placeholders
         if find_placeholders(entry):
-            return False
+            return ValidationResult(code=ValidationCode.UNFILLED_PLACEHOLDERS,
+                                    uuid=entry.uuid)
 
         # Verify that snapshots have valid collections in database
         if isinstance(entry, Snapshot):
             if not entry.origin_collection:
                 logger.debug("Snapshot does not have an origin collection")
-                return False
+                return ValidationResult(
+                    code=ValidationCode.ORIGIN_INVALID,
+                    uuid=entry.uuid,
+                    reason="Snapshot does not have an origin collection"
+                )
             if isinstance(entry.origin_collection, UUID):
                 linked_coll_uuid = entry.origin_collection
             else:
@@ -743,7 +749,11 @@ class Client:
             if not list(self.search(SearchTerm("uuid", "eq", linked_coll_uuid))):
                 logger.debug("Linked collection does not exist "
                              f"in database: {linked_coll_uuid}")
-                return False
+                return ValidationResult(
+                    code=ValidationCode.ORIGIN_INVALID,
+                    uuid=entry.uuid,
+                    reason="Snapshot's origin collection does not exist in database",
+                )
 
         # Use model validation
         return entry.validate()

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -293,23 +293,28 @@ class Client:
         authorized = self.is_user_authorized(user)
 
         if not authorized:
+            logger.debug(f"User not authorized to edit entry: {entry.uuid}")
             return False
 
         # If backend does not allow writing, all else is moot
         if not self.backend.entry_writable(entry):
+            logger.debug(f"Backend does not allow entry editing: {entry.uuid}")
             return False
 
         # preventing editing of past entries adds additional constraints
         if not self.enable_editing_past:
             # Recent entries are allowed...
             if entry.uuid in self.recent_entry_cache:
+                logger.debug(f"Entry in recents cache, editing allowed: {entry.uuid}")
                 return True
 
             # while past entries are restricted
             if list(self.search(SearchTerm("uuid", "eq", entry.uuid))):
+                logger.debug(f"Entry exists in database already, not editable: {entry.uuid}")
                 return False
 
         # Default is to allow writing, previous conditions veto this
+        logger.debug(f"Entry editable: {entry.uuid}")
         return True
 
     def save(self, entry: Entry):

--- a/superscore/client.py
+++ b/superscore/client.py
@@ -323,6 +323,8 @@ class Client:
         Should only save the parent information.  Children are to be references,
         and should not be modified by when their parent is saved.
         Perhaps this is to be left to the backend.
+        TODO:
+        - consider throwing error if this fails instead of being silent
         """
         # validate entry is valid
         # if exists, try to update
@@ -332,6 +334,10 @@ class Client:
             entry_ids = [e.uuid for e in entry.walk_children()]
         else:
             entry_ids = [entry.uuid]
+
+        # Validate before saving
+        if not self.validate(entry):
+            return
 
         # allow edits to entries that have been added in this session
         for entry_id in entry_ids:
@@ -688,16 +694,6 @@ class Client:
             return EpicsData(data=None)
         return value
 
-    def validate(self, entry: Entry):
-        """
-        Validate ``entry`` is properly formed and able to be inserted into
-        the backend.  Includes checks the following:
-        - dataclass is valid
-        - reachable from root
-        - references are not cyclical, and type-correct
-        """
-        raise NotImplementedError
-
     def convert_to_template(self, collection: Collection) -> Template:
         """
         Create a new Template from an existing Collection.
@@ -721,14 +717,33 @@ class Client:
         sub_filled.creation_time = utcnow()
         return sub_filled
 
-    def verify(self, entry: Entry) -> bool:
+    def validate(self, entry: Entry) -> bool:
         """
-        Confirm the resulting collection is valid.
-        Currently performs model validation and checks if any placeholders remain.
+        Validate ``entry`` is properly formed and able to be inserted into
+        the backend.  Verifies the following in addition to the base model
+        validation steps:
+        - checks if any placeholders remain.
+        - Verifies that Snapshots reference existing collections
         """
         # Check for remaining placeholders
         if find_placeholders(entry):
             return False
+
+        # Verify that snapshots have valid collections in database
+        if isinstance(entry, Snapshot):
+            if not entry.origin_collection:
+                logger.debug("Snapshot does not have an origin collection")
+                return False
+            if isinstance(entry.origin_collection, UUID):
+                linked_coll_uuid = entry.origin_collection
+            else:
+                linked_coll_uuid = entry.origin_collection.uuid
+
+            # while past entries are restricted
+            if not list(self.search(SearchTerm("uuid", "eq", linked_coll_uuid))):
+                logger.debug("Linked collection does not exist "
+                             f"in database: {linked_coll_uuid}")
+                return False
 
         # Use model validation
         return entry.validate()

--- a/superscore/model.py
+++ b/superscore/model.py
@@ -186,7 +186,7 @@ class Nestable:
 
     children: List[Union[UUID, Entry]]
 
-    def validate(self, toplevel: bool = True):
+    def validate(self, toplevel: bool = True) -> bool:
         """
         Validates self and all children. If toplevel, also validates structure
         of the Entry tree. This avoids redundant work by only performing tree-
@@ -282,6 +282,10 @@ class Snapshot(Nestable, Entry):
         self.children = new_children
 
         return ref_list
+
+    def validate(self, toplevel: bool = True) -> bool:
+        # TODO: Verify structure matches origin Collection?
+        return super().validate(toplevel)
 
 
 @dataclass

--- a/superscore/model.py
+++ b/superscore/model.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -12,7 +13,7 @@ from uuid import UUID, uuid4
 import apischema
 
 from superscore.serialization import as_tagged_union
-from superscore.type_hints import AnyEpicsType
+from superscore.type_hints import AnyEpicsType, AnyPath
 from superscore.utils import utcnow
 
 logger = logging.getLogger(__name__)
@@ -314,3 +315,27 @@ class Root:
 
 PVEntry = Union[Parameter, Setpoint, Readback]
 NestableEntry = Union[Collection, Snapshot]
+
+
+def get_entry_from_path(path: AnyPath) -> Entry:
+    """
+    Loads an Entry from a serialized json file.
+    Note: Entry will need to nested in a Root to properly invoke tagged union machinery
+
+    Extract the entry from the root's children.
+    TODO: Consider allowing importing multiple entries at once?
+    """
+    with open(path, "r") as fd:
+        deser = json.load(fd)
+
+    return apischema.deserialize(Root, deser).entries[0]
+
+
+def save_entry_to_path(entry: Entry, path: AnyPath):
+    """Save ``entry`` to ``path``, wrapping in a ``Root`` container"""
+    root_wrapped_entry = Root(entries=[entry])
+    ser = apischema.serialize(root_wrapped_entry)
+
+    with open(path, "w") as fd:
+        json.dump(ser, fd, indent=2)
+        fd.write("\n")

--- a/superscore/model.py
+++ b/superscore/model.py
@@ -15,6 +15,7 @@ import apischema
 from superscore.serialization import as_tagged_union
 from superscore.type_hints import AnyEpicsType, AnyPath
 from superscore.utils import utcnow
+from superscore.validation import ValidationCode, ValidationResult
 
 logger = logging.getLogger(__name__)
 _root_uuid = _root_uuid = UUID("a28cd77d-cc92-46cc-90cb-758f0f36f041")
@@ -77,7 +78,7 @@ class Entry:
         """
         return []
 
-    def validate(self, toplevel: bool = True) -> bool:
+    def validate(self, toplevel: bool = True) -> ValidationResult:
         """
         Ensures Entry is properly formed.
 
@@ -88,11 +89,16 @@ class Entry:
             try:
                 serial = apischema.serialize(self)
                 apischema.deserialize(type(self), serial)
-                return True
+                return ValidationResult(uuid=self.uuid)
             except apischema.ValidationError:
-                return False
+                return ValidationResult(
+                    uuid=self.uuid,
+                    code=ValidationCode.TYPE_ERROR,
+                    reason="Entry fields have data of improper type"
+                           "(failed serialization roundtrip)",
+                )
         else:
-            return True
+            return ValidationResult(uuid=self.uuid)
 
 
 @dataclass
@@ -104,9 +110,14 @@ class Parameter(Entry):
     readback: Optional[Parameter] = None
     read_only: bool = False
 
-    def validate(self, toplevel: bool = True) -> bool:
-        readback_is_valid = self.readback is None or self.readback.validate(toplevel=False)
-        return readback_is_valid and super().validate(toplevel=toplevel)
+    def validate(self, toplevel: bool = True) -> ValidationResult:
+        # check if readback is valid
+        if self.readback is not None:
+            readback_is_valid = self.readback.validate(toplevel=False)
+            if not readback_is_valid:
+                return readback_is_valid
+
+        return super().validate(toplevel=toplevel)
 
 
 @dataclass
@@ -135,9 +146,13 @@ class Setpoint(Entry):
             readback=origin.readback,
         )
 
-    def validate(self, toplevel: bool = True) -> bool:
-        readback_is_valid = self.readback is None or self.readback.validate(toplevel=False)
-        return readback_is_valid and super().validate(toplevel=toplevel)
+    def validate(self, toplevel: bool = True) -> ValidationResult:
+        if self.readback is not None:
+            readback_is_valid = self.readback.validate(toplevel=False)
+            if not readback_is_valid:
+                return readback_is_valid
+
+        return super().validate(toplevel=toplevel)
 
 
 @dataclass
@@ -183,10 +198,10 @@ class Readback(Entry):
 
 class Nestable:
     """Mix-in class that provides methods for nested container Entries"""
-
+    uuid: UUID
     children: List[Union[UUID, Entry]]
 
-    def validate(self, toplevel: bool = True) -> bool:
+    def validate(self, toplevel: bool = True) -> ValidationResult:
         """
         Validates self and all children. If toplevel, also validates structure
         of the Entry tree. This avoids redundant work by only performing tree-
@@ -194,8 +209,28 @@ class Nestable:
 
         Overrides Entry.validate().
         """
-        tree_is_valid = not toplevel or (not self.has_cycle() and super().validate(toplevel=True))
-        return tree_is_valid and all(child.validate(toplevel=False) for child in self.children)
+        if self.has_cycle() and toplevel:
+            return ValidationResult(
+                code=ValidationCode.CYCLE_FOUND,
+                uuid=self.uuid,
+            )
+
+        # check self validation
+        is_self_valid = super().validate(toplevel)
+        if not is_self_valid:
+            return is_self_valid
+
+        # check child validation
+        for child in self.children:
+            if isinstance(child, UUID):
+                # cannot validate un-filled uuids
+                continue
+            child_valid = child.validate(toplevel=False)
+            if not child_valid:
+                return child_valid
+
+        # everythin seems to be ok
+        return ValidationResult(uuid=self.uuid)
 
     def has_cycle(self, parents=None) -> bool:
         if parents is None:
@@ -283,7 +318,7 @@ class Snapshot(Nestable, Entry):
 
         return ref_list
 
-    def validate(self, toplevel: bool = True) -> bool:
+    def validate(self, toplevel: bool = True) -> ValidationResult:
         # TODO: Verify structure matches origin Collection?
         return super().validate(toplevel)
 

--- a/superscore/model.py
+++ b/superscore/model.py
@@ -363,6 +363,11 @@ def get_entry_from_path(path: AnyPath) -> Entry:
 
     Extract the entry from the root's children.
     TODO: Consider allowing importing multiple entries at once?
+
+    Raises
+    ------
+    apischema.ValidationError
+        if deserialization fails
     """
     with open(path, "r") as fd:
         deser = json.load(fd)

--- a/superscore/tests/conftest_data.py
+++ b/superscore/tests/conftest_data.py
@@ -772,8 +772,15 @@ def parameter_with_readback() -> Parameter:
     return setpoint
 
 
-def simple_snapshot() -> Collection:
-    snap = Snapshot(description='various types', title='types collection')
+def simple_snapshot() -> Snapshot:
+    origin_coll = Collection(description="origin of various types",
+                             children=[
+                                 Parameter(pv_name="MY:FLOAT"),
+                                 Parameter(pv_name="MY:INT"),
+                                 Parameter(pv_name="MY:ENUM"),
+                             ])
+    snap = Snapshot(description='various types', title='types collection',
+                    origin_collection=origin_coll)
     snap.children.append(Setpoint(pv_name="MY:FLOAT"))
     snap.children.append(Setpoint(pv_name="MY:INT"))
     snap.children.append(Setpoint(pv_name="MY:ENUM"))

--- a/superscore/tests/db/filestore.json
+++ b/superscore/tests/db/filestore.json
@@ -72,7 +72,7 @@
         "description": "Snapshot 1 created from collection 1",
         "creation_time": "2024-05-10T16:49:34.574911+00:00",
         "title": "snapshot 1",
-        "origin_collection": null,
+        "origin_collection": "a9f289d4-3421-4107-8e7f-2fe0daab77a5",
         "children": [
           {
             "uuid": "ecb42cdb-b703-4562-86e1-45bd67a2ab1a",

--- a/superscore/tests/export/exported_collection.json
+++ b/superscore/tests/export/exported_collection.json
@@ -1,0 +1,55 @@
+{
+  "uuid": "a28cd77d-cc92-46cc-90cb-758f0f36f041",
+  "entries": [
+    {
+      "Collection": {
+        "uuid": "242b57a5-0e3a-4086-9725-575137ac9c9f",
+        "description": "mtr1 collection",
+        "creation_time": "2026-02-06T23:16:27.833320+00:00",
+        "children": [
+          {
+            "uuid": "392bedb1-22c1-4370-9b4c-c5bba71d5c32",
+            "description": "",
+            "creation_time": "2026-02-06T23:16:48.854638+00:00",
+            "pv_name": "MY:PREFIX:mtr1",
+            "abs_tolerance": null,
+            "rel_tolerance": null,
+            "readback": {
+              "uuid": "ea66165b-6cbd-4925-be12-2f5c85849a52",
+              "description": "",
+              "creation_time": "2026-02-06T23:16:48.854627+00:00",
+              "pv_name": "MY:PREFIX:mtr1.RBV",
+              "abs_tolerance": null,
+              "rel_tolerance": null,
+              "readback": null,
+              "read_only": true
+            },
+            "read_only": false
+          },
+          {
+            "uuid": "3fe2ad46-5b44-41de-a0a9-cac1a9f9c905",
+            "description": "",
+            "creation_time": "2026-02-06T23:17:35.113734+00:00",
+            "pv_name": "MY:PREFIX:mtr1.ACCL",
+            "abs_tolerance": null,
+            "rel_tolerance": null,
+            "readback": null,
+            "read_only": false
+          },
+          {
+            "uuid": "980022e2-55cd-499a-b45c-12eff4d68b6d",
+            "description": "",
+            "creation_time": "2026-02-06T23:17:35.115181+00:00",
+            "pv_name": "MY:PREFIX:mtr1.VELO",
+            "abs_tolerance": null,
+            "rel_tolerance": null,
+            "readback": null,
+            "read_only": false
+          }
+        ],
+        "title": "motor1 coll",
+        "tags": []
+      }
+    }
+  ]
+}

--- a/superscore/tests/export/exported_setpoint.json
+++ b/superscore/tests/export/exported_setpoint.json
@@ -1,0 +1,17 @@
+{
+  "uuid": "a28cd77d-cc92-46cc-90cb-758f0f36f041",
+  "entries": [
+    {
+      "Setpoint": {
+        "uuid": "e98322df-b894-48d5-b284-86483194d1ee",
+        "description": "",
+        "creation_time": "2026-01-09T18:59:30.320598+00:00",
+        "pv_name": "IM1L0:XTES:MMS:STATE:GET_RBV",
+        "data": null,
+        "status": 17,
+        "severity": 3,
+        "readback": null
+      }
+    }
+  ]
+}

--- a/superscore/tests/export/exported_snapshot.json
+++ b/superscore/tests/export/exported_snapshot.json
@@ -1,0 +1,48 @@
+{
+  "uuid": "a28cd77d-cc92-46cc-90cb-758f0f36f041",
+  "entries": [
+    {
+      "Snapshot": {
+        "uuid": "ce1d7818-9405-448e-8004-9b121a3a954b",
+        "description": "Snapshot 1 created from collection 1",
+        "creation_time": "2026-01-13T17:19:25.091070+00:00",
+        "children": [
+          {
+            "uuid": "d281b08e-7aa0-4e2d-bf5d-36bd989f461a",
+            "description": "",
+            "creation_time": "2026-01-13T17:19:25.091080+00:00",
+            "pv_name": "MY:PREFIX:mtr1.ACCL",
+            "data": 2,
+            "status": 17,
+            "severity": 3,
+            "readback": null
+          },
+          {
+            "uuid": "619ea3cf-9ab0-4ca2-a1ca-3be2539e8ca6",
+            "description": "",
+            "creation_time": "2026-01-13T17:19:25.091090+00:00",
+            "pv_name": "MY:PREFIX:mtr1.VELO",
+            "data": 2,
+            "status": 17,
+            "severity": 3,
+            "readback": null
+          },
+          {
+            "uuid": "4acf2759-4571-4f0c-8b19-a3c1cf587084",
+            "description": "",
+            "creation_time": "2026-01-13T17:19:25.091098+00:00",
+            "pv_name": "MY:PREFIX:mtr1.PREC",
+            "data": 6,
+            "status": 17,
+            "severity": 3,
+            "readback": null
+          }
+        ],
+        "title": "snapshot 1",
+        "origin_collection": "f91e5c52-5956-4e35-bfa5-716aeee80b51",
+        "tags": [],
+        "meta_pvs": []
+      }
+    }
+  ]
+}

--- a/superscore/tests/export/exported_template.json
+++ b/superscore/tests/export/exported_template.json
@@ -1,0 +1,65 @@
+{
+  "uuid": "a28cd77d-cc92-46cc-90cb-758f0f36f041",
+  "entries": [
+    {
+      "Template": {
+        "uuid": "5b95020d-0192-40e3-bded-d53050fa21e7",
+        "description": "",
+        "creation_time": "2026-02-12T23:54:45.181674+00:00",
+        "title": "Template for motor1 coll",
+        "template_collection": {
+          "uuid": "242b57a5-0e3a-4086-9725-575137ac9c9f",
+          "description": "mtr1 collection",
+          "creation_time": "2026-02-06T23:16:27.833320+00:00",
+          "children": [
+            {
+              "uuid": "392bedb1-22c1-4370-9b4c-c5bba71d5c32",
+              "description": "",
+              "creation_time": "2026-02-06T23:16:48.854638+00:00",
+              "pv_name": "MY:PREFIX:mtr1",
+              "abs_tolerance": null,
+              "rel_tolerance": null,
+              "readback": {
+                "uuid": "ea66165b-6cbd-4925-be12-2f5c85849a52",
+                "description": "",
+                "creation_time": "2026-02-06T23:16:48.854627+00:00",
+                "pv_name": "MY:PREFIX:mtr1.RBV",
+                "abs_tolerance": null,
+                "rel_tolerance": null,
+                "readback": null,
+                "read_only": true
+              },
+              "read_only": false
+            },
+            {
+              "uuid": "3fe2ad46-5b44-41de-a0a9-cac1a9f9c905",
+              "description": "",
+              "creation_time": "2026-02-06T23:17:35.113734+00:00",
+              "pv_name": "MY:PREFIX:mtr1.ACCL",
+              "abs_tolerance": null,
+              "rel_tolerance": null,
+              "readback": null,
+              "read_only": false
+            },
+            {
+              "uuid": "980022e2-55cd-499a-b45c-12eff4d68b6d",
+              "description": "",
+              "creation_time": "2026-02-06T23:17:35.115181+00:00",
+              "pv_name": "MY:PREFIX:mtr1.VELO",
+              "abs_tolerance": null,
+              "rel_tolerance": null,
+              "readback": null,
+              "read_only": false
+            }
+          ],
+          "title": "motor1 coll",
+          "tags": []
+        },
+        "placeholders": {
+          "mtr1": "num",
+          "MY:PREFIX": "hi"
+        }
+      }
+    }
+  ]
+}

--- a/superscore/tests/test_client.py
+++ b/superscore/tests/test_client.py
@@ -308,7 +308,7 @@ def test_recents_cache(test_client):
     ])
     assert colls_in_cache
 
-    snap = Snapshot()
+    snap = Snapshot(origin_collection=coll)
     existing_entry = test_client.backend.get_entry(
         UUID("2f709b4b-79da-4a8b-8693-eed2c389cb3a")
     )

--- a/superscore/tests/test_page.py
+++ b/superscore/tests/test_page.py
@@ -54,7 +54,12 @@ def collection_page(qtbot: QtBot, test_client: Client, mock_window: Window):
 
 @pytest.fixture(scope="function")
 def snapshot_page(qtbot: QtBot, test_client: Client, mock_window: Window):
-    data = Snapshot(children=[Setpoint(pv_name="ORIG:NAME"), Snapshot()])
+    origin_coll = Collection()
+    # Snapshots require origin collections to exist
+    test_client.save(origin_coll)
+
+    data = Snapshot(children=[Setpoint(pv_name="ORIG:NAME"), Snapshot()],
+                    origin_collection=origin_coll)
     page = SnapshotPage(data=data, client=test_client)
     qtbot.addWidget(page)
     yield page

--- a/superscore/tests/test_page.py
+++ b/superscore/tests/test_page.py
@@ -15,6 +15,7 @@ from superscore.control_layers._base_shim import EpicsData
 from superscore.model import (Collection, Parameter, Readback, Setpoint,
                               Severity, Snapshot, Status)
 from superscore.tests.conftest import setup_test_stack
+from superscore.validation import ValidationCode, ValidationResult
 from superscore.widgets.page.collection_builder import CollectionBuilderPage
 from superscore.widgets.page.diff import DiffPage
 from superscore.widgets.page.entry import (BaseParameterPage, CollectionPage,
@@ -523,3 +524,30 @@ def test_nest_page_dirty_save(
         assert isinstance(widget, QtWidgets.QWidget)
         # .isHidden can still be False if a parent widget is hidden.
         assert not widget.isVisible()
+
+
+@pytest.mark.parametrize('page', [
+    "parameter_page",
+    "setpoint_page",
+    "readback_page",
+    "collection_page",
+    "snapshot_page"
+])
+@setup_test_stack(sources=["db/filestore.json"], backend_type=[FilestoreBackend, DirectoryBackend])
+def test_invalid_entry_save_disable(
+    test_client: Client,
+    page: str,
+    request: pytest.FixtureRequest,
+    monkeypatch,
+):
+    page_widget = request.getfixturevalue(page)
+    assert isinstance(page_widget, (BaseParameterPage, NestablePage))
+    monkeypatch.setattr(
+        Client, "validate",
+        lambda *args, **kwargs: ValidationResult(
+            uuid=page_widget.data.uuid,
+            code=ValidationCode.TYPE_ERROR
+        )
+    )
+    page_widget.update_dirty_status()
+    assert not page_widget.save_button.isEnabled()

--- a/superscore/tests/test_status.py
+++ b/superscore/tests/test_status.py
@@ -35,6 +35,7 @@ async def long_coroutine_status() -> TaskStatus:
     return inner_coroutine()
 
 
+@pytest.mark.asyncio
 async def test_status_success(normal_coroutine):
     st = TaskStatus(normal_coroutine())
     assert isinstance(st, TaskStatus)
@@ -45,6 +46,7 @@ async def test_status_success(normal_coroutine):
     assert st.success
 
 
+@pytest.mark.asyncio
 async def test_status_fail(failing_coroutine):
     status = TaskStatus(failing_coroutine())
     assert status.exception() is None
@@ -82,6 +84,7 @@ def test_status_wait(long_coroutine_status):
     assert isinstance(long_coroutine_status.exception(), asyncio.CancelledError)
 
 
+@pytest.mark.asyncio
 async def test_status_wrap():
     @TaskStatus.wrap
     async def coro_status():

--- a/superscore/tests/test_status.py
+++ b/superscore/tests/test_status.py
@@ -2,11 +2,12 @@ import asyncio
 from typing import Any, Callable
 
 import pytest
+import pytest_asyncio
 
 from superscore.control_layers.status import TaskStatus
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def normal_coroutine() -> Callable[[], Any]:
     async def inner_coroutine():
         await asyncio.sleep(0.01)
@@ -14,7 +15,7 @@ async def normal_coroutine() -> Callable[[], Any]:
     return inner_coroutine
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def failing_coroutine() -> Callable[[], Any]:
     async def inner_coroutine():
         await asyncio.sleep(0.01)
@@ -23,7 +24,7 @@ async def failing_coroutine() -> Callable[[], Any]:
     return inner_coroutine
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def long_coroutine_status() -> TaskStatus:
     @TaskStatus.wrap
     async def inner_coroutine():

--- a/superscore/tests/test_templates.py
+++ b/superscore/tests/test_templates.py
@@ -128,8 +128,8 @@ def test_client_template(test_client: Client):
     assert filled.children[0].pv_name == "X:PV"
     assert filled.creation_time != coll.creation_time
 
-    assert test_client.verify(filled) is True
+    assert test_client.validate(filled) is True
 
     # Test verify failure with missing substitutions
     partially_filled = test_client.fill_template(template, {"id": "42"})
-    assert test_client.verify(partially_filled) is False
+    assert test_client.validate(partially_filled) is False

--- a/superscore/tests/test_templates.py
+++ b/superscore/tests/test_templates.py
@@ -128,8 +128,8 @@ def test_client_template(test_client: Client):
     assert filled.children[0].pv_name == "X:PV"
     assert filled.creation_time != coll.creation_time
 
-    assert test_client.validate(filled) is True
+    assert test_client.validate(filled)
 
     # Test verify failure with missing substitutions
     partially_filled = test_client.fill_template(template, {"id": "42"})
-    assert test_client.validate(partially_filled) is False
+    assert not test_client.validate(partially_filled)

--- a/superscore/tests/test_views.py
+++ b/superscore/tests/test_views.py
@@ -12,9 +12,8 @@ from superscore.backends.filestore import FilestoreBackend
 from superscore.backends.test import TestBackend
 from superscore.client import Client
 from superscore.control_layers import EpicsData
-from superscore.model import (Collection, Nestable, Parameter, PVEntry,
-                              Readback, Root, Setpoint, Severity, Snapshot,
-                              Status)
+from superscore.model import (Nestable, Parameter, PVEntry, Readback, Root,
+                              Setpoint, Severity, Snapshot, Status)
 from superscore.tests.conftest import nest_depth, setup_test_stack
 from superscore.widgets.views import (CustRoles, EntryItem, LivePVHeader,
                                       LivePVTableModel, LivePVTableView,
@@ -52,7 +51,7 @@ def pv_poll_model(
 @pytest.fixture(scope="function")
 def pv_table_view(
     test_client: Client,
-    simple_snapshot_fixture: Collection,
+    simple_snapshot_fixture: Snapshot,
     qtbot: QtBot,
 ):
     """
@@ -271,10 +270,11 @@ def test_rbv_pairs(pv_poll_model: LivePVTableModel, setpoint_with_readback_fixtu
 @setup_test_stack(sources=['db/filestore.json'], backend_type=FilestoreBackend)
 def test_fill_uuids_pvs(
     test_client: Client,
-    simple_snapshot_fixture: Collection,
+    simple_snapshot_fixture: Snapshot,
     qtbot: QtBot,
 ):
     """Verify UUID data gets filled, and dataclass gets modified"""
+    test_client.save(simple_snapshot_fixture.origin_collection)
     test_client.save(simple_snapshot_fixture)
     simple_snapshot_fixture.swap_to_uuids()
     assert all(isinstance(c, UUID) for c in simple_snapshot_fixture.children)

--- a/superscore/tests/test_window.py
+++ b/superscore/tests/test_window.py
@@ -1,13 +1,17 @@
+from pathlib import Path
 from uuid import UUID
 
 import pytest
 from pytestqt.qtbot import QtBot
 from qtpy import QtWidgets
 
+from superscore.backends.directory import DirectoryBackend
 from superscore.backends.filestore import FilestoreBackend
 from superscore.client import Client
-from superscore.model import Snapshot
+from superscore.model import (Collection, Entry, Setpoint, Snapshot, Template,
+                              get_entry_from_path)
 from superscore.tests.conftest import setup_test_stack
+from superscore.widgets.core import DataWidget
 from superscore.widgets.page.collection_builder import CollectionBuilderPage
 from superscore.widgets.page.entry import (CollectionPage, ParameterPage,
                                            SetpointPage, SnapshotPage)
@@ -168,3 +172,48 @@ def test_open_page_editability(qtbot, test_client: Client, editable: bool,):
         assert page.editable == editable
         # close the polling loops so we don't wait for them all at once
         page.close()
+
+
+@pytest.mark.parametrize("filename,expected_entry_type", [
+    ("exported_setpoint.json", Setpoint),
+    ("exported_template.json", Template),
+    ("exported_collection.json", Collection),
+])
+@setup_test_stack(
+    sources=["db/filestore.json",],
+    backend_type=[FilestoreBackend, DirectoryBackend],
+)
+def test_import_export(
+    qtbot: QtBot,
+    test_client: Client,
+    filename: str,
+    expected_entry_type: type[Entry],
+    tmp_path: Path,
+    monkeypatch,
+):
+    window = Window(client=test_client)
+    qtbot.addWidget(window)
+
+    import_file_path = Path(__file__).parent / "export" / filename
+
+    window.import_from_file(import_file_path)
+
+    page_widget = window.tab_widget.currentWidget()
+    assert isinstance(page_widget, DataWidget)
+    assert isinstance(page_widget.data, expected_entry_type)
+
+    # check that round trip yields similar dataclasses
+    export_path = tmp_path / "export_data.json"
+
+    def return_export_path(*args, **kwargs):
+        return export_path, None
+
+    monkeypatch.setattr(QtWidgets.QFileDialog, "getSaveFileName", return_export_path)
+    window.export_current_tab_data()
+
+    data_1 = get_entry_from_path(import_file_path)
+    data_2 = get_entry_from_path(export_path)
+
+    data_1.uuid = data_2.uuid
+
+    assert data_1 == data_2

--- a/superscore/tests/test_window.py
+++ b/superscore/tests/test_window.py
@@ -178,6 +178,7 @@ def test_open_page_editability(qtbot, test_client: Client, editable: bool,):
     ("exported_setpoint.json", Setpoint),
     ("exported_template.json", Template),
     ("exported_collection.json", Collection),
+    ("exported_snapshot.json", Snapshot),
 ])
 @setup_test_stack(
     sources=["db/filestore.json",],

--- a/superscore/tests/test_window.py
+++ b/superscore/tests/test_window.py
@@ -6,6 +6,7 @@ from qtpy import QtWidgets
 
 from superscore.backends.filestore import FilestoreBackend
 from superscore.client import Client
+from superscore.model import Snapshot
 from superscore.tests.conftest import setup_test_stack
 from superscore.widgets.page.collection_builder import CollectionBuilderPage
 from superscore.widgets.page.entry import (CollectionPage, ParameterPage,
@@ -107,6 +108,8 @@ def test_take_snapshot(qtbot: QtBot, test_client: Client, monkeypatch):
         ("uuid", "eq", UUID("ffd668d3-57d9-404e-8366-0778af7aee61"))
     ))[0]
 
+    assert isinstance(snapshot, Snapshot)
+
     collection_page = window.open_page(collection)
     new_snapshot = collection_page.take_snapshot()
     collection_page.children()[-1].done(1)
@@ -115,6 +118,8 @@ def test_take_snapshot(qtbot: QtBot, test_client: Client, monkeypatch):
 
     # cannot take snapshot without a relevant origin collection
     snapshot_page = window.open_page(snapshot)
+    # Database has proper data linkage/validation, break this for testing purposes
+    snapshot_page.data.origin_collection = None
     assert isinstance(snapshot_page, SnapshotPage)
     result = snapshot_page.take_snapshot()
     assert result is None

--- a/superscore/ui/main_window.ui
+++ b/superscore/ui/main_window.ui
@@ -100,6 +100,8 @@
     </widget>
     <addaction name="separator"/>
     <addaction name="menu_new"/>
+    <addaction name="action_import"/>
+    <addaction name="action_export"/>
    </widget>
    <widget class="QMenu" name="menuDebug">
     <property name="title">
@@ -174,6 +176,16 @@
   <action name="action_new_coll">
    <property name="text">
     <string>Collection</string>
+   </property>
+  </action>
+  <action name="action_import">
+   <property name="text">
+    <string>Import Data</string>
+   </property>
+  </action>
+  <action name="action_export">
+   <property name="text">
+    <string>Export Current Data</string>
    </property>
   </action>
  </widget>

--- a/superscore/ui/nestable_page.ui
+++ b/superscore/ui/nestable_page.ui
@@ -50,6 +50,13 @@
          </widget>
         </item>
         <item>
+         <widget class="QPushButton" name="open_origin_button">
+          <property name="text">
+           <string>Open Parent Collection</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QPushButton" name="restore_button">
           <property name="text">
            <string>Restore Snapshot</string>

--- a/superscore/validation.py
+++ b/superscore/validation.py
@@ -1,0 +1,43 @@
+"""Validation Result Information bundle"""
+
+from dataclasses import dataclass
+from enum import Enum, auto
+from uuid import UUID
+
+
+class ValidationCode(Enum):
+    """Terse Validation reasons"""
+    # TODO: consider flags for more thorough validation codes (combinations)
+    # Will only be relevant if validation routines don't terminate early
+    VALID = (auto(), "")
+    CYCLE_FOUND = (auto(), "Cycle in data hierarchy.  Parent can be re-reached from children")
+    ORIGIN_INVALID = (auto(), "Origin of Entry is either null or does not exist")
+    TYPE_ERROR = (auto(), "Entry has data of invalid type")
+    READBACK_INVALID = (auto(), "Entry has an invalid readback")
+    UNFILLED_PLACEHOLDERS = (auto(), "Entry has unfilled placeholders, please fill before saving")
+
+    def __init__(self, value, description: str):
+        self._value_ = value
+        self.description = description
+
+
+@dataclass(frozen=True)
+class ValidationResult:
+    # UUID of entry being validated
+    uuid: UUID
+    # Reason for validation status
+    code: ValidationCode = ValidationCode.VALID
+    # Verbose reason, with information to supplement the ValidationCode
+    reason: str = ""
+
+    def __bool__(self) -> bool:
+        return self.code is ValidationCode.VALID
+
+    def __str__(self) -> str:
+        msg = f"Entry with uuid {self.uuid}"
+        if self:
+            msg += "is valid"
+        else:
+            msg += f"is not valid: {self.reason}"
+
+        return msg

--- a/superscore/widgets/page/entry.py
+++ b/superscore/widgets/page/entry.py
@@ -455,7 +455,7 @@ class BaseParameterPage[PVT: PVEntry](Display, DataWidget[PVT]):
             widget.bridge.pv_name.changed_value.connect(self.rbv_pv_label.setText)
 
     def create_rbv(self):
-        new_rbv = Readback(pv_name='<MY:PV>')
+        new_rbv = self.RBVCls(pv_name='<MY:PV>')
         self.bridge.readback.put(new_rbv)
         self.open_rbv_page()
 
@@ -488,7 +488,7 @@ class ParameterPage(BaseParameterPage[Parameter]):
 
 
 class SetpointPage(BaseParameterPage[Setpoint]):
-    pass
+    RBVCls = Readback
 
 
 class ReadbackPage(BaseParameterPage[Readback]):

--- a/superscore/widgets/page/entry.py
+++ b/superscore/widgets/page/entry.py
@@ -37,6 +37,7 @@ class NestablePage[NT: NestableEntry](Display, DataWidget[NT]):
 
     save_button: QtWidgets.QPushButton
     snapshot_button: QtWidgets.QPushButton
+    open_origin_button: QtWidgets.QPushButton
     restore_button: QtWidgets.QPushButton
     convert_template_button: QtWidgets.QPushButton
 
@@ -124,12 +125,32 @@ class NestablePage[NT: NestableEntry](Display, DataWidget[NT]):
             self._dirty, self.sub_coll_table_view.dirty, self.sub_pv_table_view.dirty
         ))
         logger.debug(f"Entry {self.data.uuid} Dirty?: {self.dirty}")
-        if self.dirty:
-            self.save_button.setText("Save *")
-            self.save_button.setEnabled(True)
+
+        # Baseline is enbled button, give helpful tooltips depending on reason
+        enabled = True
+        reasons = []
+        if self.client is None:
+            reasons.append("No client assigned.")
+            enabled = False
+
+        if self.client is None:
+            validation_result = self.data.validate()
+            enabled = False
         else:
-            self.save_button.setText("Save")
-            self.save_button.setEnabled(False)
+            validation_result = self.client.validate(self.data)
+
+        if not validation_result:
+            reasons.append(validation_result.reason)
+            enabled = False
+
+        # Finally enable if data is dirty
+        if self.dirty and enabled:
+            self.save_button.setText("Save *")
+            self.save_button.setToolTip("")
+        else:
+            self.save_button.setToolTip("\n".join(reasons))
+
+        self.save_button.setEnabled(enabled)
 
     def closeEvent(self, a0: QCloseEvent) -> None:
         logger.debug(f"Stopping polling threads for {type(self.data)}")
@@ -190,6 +211,7 @@ class CollectionPage(NestablePage[Collection]):
     def setup_ui(self):
         super().setup_ui()
         self.restore_button.hide()
+        self.open_origin_button.hide()
         self.convert_template_button.show()
 
 
@@ -199,9 +221,17 @@ class SnapshotPage(NestablePage[Snapshot]):
         super().setup_ui()
         self.convert_template_button.hide()
         window = self.get_window()
-        if window is not None:
-            self.restore_button.clicked.connect(
-                partial(window.open_restore_page, snapshot=self.data)
+        if window is None:
+            return
+
+        self.restore_button.clicked.connect(
+            partial(window.open_restore_page, snapshot=self.data)
+        )
+        if self.data.origin_collection is None:
+            self.open_origin_button.setEnabled(False)
+        else:
+            self.open_origin_button.clicked.connect(
+                partial(window.open_page, self.data.origin_collection)
             )
 
 
@@ -239,6 +269,7 @@ class BaseParameterPage[PVT: PVEntry](Display, DataWidget[PVT]):
     rbv_pv_label: QtWidgets.QLabel
 
     save_button: QtWidgets.QPushButton
+    RBVCls = Parameter
 
     _edata_thread: Optional[BusyCursorThread]
 
@@ -475,12 +506,31 @@ class BaseParameterPage[PVT: PVEntry](Display, DataWidget[PVT]):
         self.update_dirty_status()
 
     def update_dirty_status(self):
-        if self.dirty:
-            self.save_button.setText("Save *")
-            self.save_button.setEnabled(True)
+        # Baseline is enbled button, give helpful tooltips depending on reason
+        enabled = True
+        reasons = []
+        if self.client is None:
+            reasons.append("No client assigned.")
+            enabled = False
+
+        if self.client is None:
+            validation_result = self.data.validate()
+            enabled = False
         else:
-            self.save_button.setText("Save")
-            self.save_button.setEnabled(False)
+            validation_result = self.client.validate(self.data)
+
+        if not validation_result:
+            reasons.append(validation_result.reason)
+            enabled = False
+
+        # Finally enable if data is dirty
+        if self.dirty and enabled:
+            self.save_button.setText("Save *")
+            self.save_button.setToolTip("")
+        else:
+            self.save_button.setToolTip("\n".join(reasons))
+
+        self.save_button.setEnabled(enabled)
 
 
 class ParameterPage(BaseParameterPage[Parameter]):

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import logging
 from functools import partial
 from typing import ClassVar, Optional, cast
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import qtawesome as qta
 from qtpy import QtCore, QtWidgets
@@ -14,7 +14,9 @@ from qtpy.QtGui import QCloseEvent
 
 from superscore.client import CallbackType, Client
 from superscore.errors import EntryNotFoundError
-from superscore.model import Entry, Snapshot
+from superscore.model import (Entry, Snapshot, get_entry_from_path,
+                              save_entry_to_path)
+from superscore.type_hints import AnyPath
 from superscore.widgets import ICON_MAP
 from superscore.widgets.core import DataWidget, Display, QtSingleton
 from superscore.widgets.page import PAGE_MAP
@@ -37,6 +39,8 @@ class Window(Display, QtWidgets.QMainWindow, metaclass=QtSingleton):
     tab_widget: QtWidgets.QTabWidget
 
     action_new_coll: QtWidgets.QAction
+    action_import: QtWidgets.QAction
+    action_export: QtWidgets.QAction
 
     entry_saved: ClassVar[QtCore.Signal] = QtCore.Signal(UUID)
     entry_deleted: ClassVar[QtCore.Signal] = QtCore.Signal(UUID)
@@ -76,6 +80,8 @@ class Window(Display, QtWidgets.QMainWindow, metaclass=QtSingleton):
 
         # setup actions
         self.action_new_coll.triggered.connect(self.open_collection_builder)
+        self.action_import.triggered.connect(self.import_action_slot)
+        self.action_export.triggered.connect(self.export_action_slot)
 
         # open diff page
         self.diff_dispatcher.comparison_ready.connect(self.open_diff_page)
@@ -204,6 +210,64 @@ class Window(Display, QtWidgets.QMainWindow, metaclass=QtSingleton):
             restore_page_action.triggered.connect(partial(self.open_restore_page, entry))
 
         return menu
+
+    def import_action_slot(self, checked: bool = False):
+        self.import_from_file()
+
+    def import_from_file(self, filename: Optional[AnyPath] = None):
+        """Prompt for, import a dataclass from serialized json, open the appropriate page"""
+        if filename is None:
+            filename, _ = QtWidgets.QFileDialog.getOpenFileName(
+                parent=self,
+                caption='Select Entry Data',
+                filter='Json Files (*.json)',
+            )
+        if not filename:
+            return
+
+        try:
+            data = get_entry_from_path(filename)
+        except ValueError:
+            logger.error("Failed to open file")
+            msg = QtWidgets.QMessageBox(parent=self)
+            msg.setIcon(QtWidgets.QMessageBox.Critical)
+            msg.setText("Failed to read Entry data from file"
+                        "The file may be corrupted or malformed.")
+            msg.setWindowTitle('Could not open file')
+            msg.exec_()
+            return
+
+        # get new uuid to prevent collision with existing data
+        data.uuid = uuid4()
+
+        # if has reference to collection uuid, check that it exists in db
+        # if missing, request the collection be imported as well.
+        self.open_page(entry=data)
+
+    def export_action_slot(self, checked: bool = False):
+        self.export_current_tab_data()
+
+    def export_current_tab_data(self):
+        """Export the data on a currently active tab.  Prompt for serialization location"""
+        widget = self.tab_widget.currentWidget()
+
+        if not isinstance(widget, DataWidget) or (type(widget) not in PAGE_MAP.values()):
+            raise ValueError("Current page does not hold an exportable Entry.")
+
+        data = widget.data
+
+        filepath, _ = QtWidgets.QFileDialog.getSaveFileName(
+            parent=self,
+            caption='Select path to save Entry data',
+            filter='Json Files (*.json)',
+        )
+
+        filepath = str(filepath)
+
+        if not filepath.endswith(".json"):
+            filepath += ".json"
+
+        save_entry_to_path(data, filepath)
 
     def closeEvent(self, a0: QCloseEvent) -> None:
         # hide to mimic closing, and prevent confusion

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -9,6 +9,7 @@ from typing import ClassVar, Optional, cast
 from uuid import UUID, uuid4
 
 import qtawesome as qta
+from apischema import ValidationError
 from qtpy import QtCore, QtWidgets
 from qtpy.QtGui import QCloseEvent
 
@@ -227,7 +228,7 @@ class Window(Display, QtWidgets.QMainWindow, metaclass=QtSingleton):
 
         try:
             data = get_entry_from_path(filename)
-        except ValueError:
+        except ValidationError:
             logger.error("Failed to open file")
             msg = QtWidgets.QMessageBox(parent=self)
             msg.setIcon(QtWidgets.QMessageBox.Critical)

--- a/superscore/widgets/window.py
+++ b/superscore/widgets/window.py
@@ -132,7 +132,7 @@ class Window(Display, QtWidgets.QMainWindow, metaclass=QtSingleton):
         self.tab_widget.addTab(page, 'new collection')
         self.tab_widget.setCurrentWidget(page)
 
-    def open_page(self, entry: Entry) -> DataWidget:
+    def open_page(self, entry: Entry | UUID) -> DataWidget:
         """
         Open a page for ``entry`` in a new tab.
 
@@ -147,9 +147,9 @@ class Window(Display, QtWidgets.QMainWindow, metaclass=QtSingleton):
             Created widget, for cross references
         """
         logger.debug(f'attempting to open {entry}')
-        if not isinstance(entry, Entry):
-            logger.debug('Could not open page for non-Entry dataclass')
-            return
+        if isinstance(entry, UUID):
+            # try to get matching entry from database
+            entry = self.client.get_entry(entry)
 
         if type(entry) not in PAGE_MAP:
             logger.debug(f'No page corresponding to {type(entry).__name__}')


### PR DESCRIPTION
## Description
- Adds import / export functionality as a menu option
  - importing simply opens the requested page in a new page, for the user to save manually
  - These new pages get new uuids, the serialized uuids get ignored (this is unclear but there's no easy way to omit it without re-rolling a serialization framework or mangling the datastructure)
- Requires Snapshots to have existing origin collections during a client.save
- Adds (de)serialization helpers to `superscore.model`
  - we wrap these in a `Root` object to let the tagged union subclass detection ffom apischema work.
- Refactors validation methods/helpers to return a `ValidationResult` dataclass rather than a simple boolean, allowing reasons to be passed through the application
  - These are bool-like, so they should be useable in the same contexts as before
- adds "open origin" button to snapshot page
- Adds logic to entry pages to check validation status as a condition for enabling the save button, complete with semi helpful tooltip

TODO: (deferred to later effort)
- adjust pages to be dirty after import

## Motivation and Context
Requested by Usman as the final feature for Superscore before beta release.  For opening the door to external-to-superscore workflows
<img width="407" height="206" alt="image" src="https://github.com/user-attachments/assets/df25cb85-7bd2-4184-be5b-51cdd89f6815" />
<img width="658" height="564" alt="image" src="https://github.com/user-attachments/assets/1f1659f1-d791-42f7-8659-e60707995fab" />

A note of caution, currently there is no way to link a snapshot to a specific collection.  If you want to upload a valid snapshot you'll have to know what uuid to reference as the origin collection.  This is trivially done by exporting an existing valid snapshot and modifying it.
There is also no verification that the parent collection matches the child snapshot, but they asked for arbitrary data and there's only so much I want to patch around the back door🤷 

### General musings
Every time I look at this project I uncover a slew of database validation conditions that may or may not belong in the client. 

Because the db has no logic, we keep this in application code, but I should probably be clearer about what logic lives where to avoid fragmentation

Frankly, this request makes more work for us since we have to now ingest and validate json blobs given to us by random users.  However It's a good escape hatch and we'll need to eventually be measured about validation anyway.

## How Has This Been Tested?
tests have been added

## Where Has This Been Documented?
This PR

## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
