### PR TITLE
ENH: add batch restore capability

### DIFF
--- a/docs/source/upcoming_release_notes/153-enh_batch_restore.rst
+++ b/docs/source/upcoming_release_notes/153-enh_batch_restore.rst
@@ -1,0 +1,22 @@
+153 enh_batch_restore
+#####################
+
+API Breaks
+----------
+- N/A
+
+Features
+--------
+- Add batch restore functionality to RestoreDialog
+
+Bugfixes
+--------
+- N/A
+
+Maintenance
+-----------
+- N/A
+
+Contributors
+------------
+- tangkong

--- a/superscore/tests/conftest.py
+++ b/superscore/tests/conftest.py
@@ -16,8 +16,8 @@ from superscore.backends.test import TestBackend
 from superscore.client import Client
 from superscore.control_layers._base_shim import _BaseShim
 from superscore.control_layers.core import ControlLayer
-from superscore.model import (Collection, Entry, Nestable, Parameter, Root,
-                              Setpoint)
+from superscore.model import (Entry, Nestable, Parameter, Root, Setpoint,
+                              Snapshot)
 from superscore.tests.ioc import IOCFactory
 from superscore.widgets.views import EntryItem
 from superscore.widgets.window import Window
@@ -50,7 +50,7 @@ def parameter_with_readback_fixture() -> Parameter:
 
 
 @pytest.fixture(scope='function')
-def simple_snapshot_fixture() -> Collection:
+def simple_snapshot_fixture() -> Snapshot:
     return simple_snapshot()
 
 

--- a/superscore/tests/test_page.py
+++ b/superscore/tests/test_page.py
@@ -22,7 +22,8 @@ from superscore.widgets.page.entry import (BaseParameterPage, CollectionPage,
                                            NestablePage, ParameterPage,
                                            ReadbackPage, SetpointPage,
                                            SnapshotPage)
-from superscore.widgets.page.restore import RestoreDialog, RestorePage
+from superscore.widgets.page.restore import (RestoreDialog, RestoreDialogModel,
+                                             RestorePage)
 from superscore.widgets.page.search import SearchPage
 from superscore.widgets.views import HeaderEnum, LivePVHeader
 from superscore.widgets.window import Window
@@ -344,27 +345,52 @@ def test_restore_dialog_restore(
 ):
     put_mock = test_client.cl.put
     dialog = RestoreDialog(test_client, simple_snapshot_fixture)
-    dialog.restore()
+    dialog.restore_all()
     assert put_mock.call_args.args == test_client._gather_data(simple_snapshot_fixture)
 
 
 @setup_test_stack(sources=["db/filestore.json"], backend_type=FilestoreBackend)
 def test_restore_dialog_remove_pv(
     test_client: Client,
-    simple_snapshot_fixture: Snapshot
+    simple_snapshot_fixture: Snapshot,
+    qtbot: QtBot
 ):
     dialog = RestoreDialog(test_client, simple_snapshot_fixture)
-    tableWidget = dialog.tableWidget
-    assert tableWidget.rowCount() == len(simple_snapshot_fixture.children)
+    qtbot.addWidget(dialog)
+    table_view = dialog.table_view
+    model = table_view.model()
+    assert isinstance(model, RestoreDialogModel)
+    assert len(model.entries) == len(simple_snapshot_fixture.children)
 
-    PV_COLUMN = 0
     REMOVE_BUTTON_COLUMN = 2
-    item_to_remove = tableWidget.item(1, PV_COLUMN)
-    tableWidget.setCurrentCell(1, REMOVE_BUTTON_COLUMN)
-    dialog.delete_row()
-    assert tableWidget.rowCount() == len(simple_snapshot_fixture.children) - 1
-    items_left = [tableWidget.item(row, PV_COLUMN) for row in range(tableWidget.rowCount())]
-    assert item_to_remove not in items_left
+    item_to_remove = model.entries[1]
+    index = model.index(1, REMOVE_BUTTON_COLUMN)
+    remove_delegate = table_view.itemDelegate(index)
+    remove_delegate.clicked.emit(index)
+    assert model.rowCount() == len(simple_snapshot_fixture.children) - 1
+    assert item_to_remove not in model.entries
+
+
+@setup_test_stack(sources=["db/filestore.json"], backend_type=FilestoreBackend)
+def test_restore_batch(
+    test_client: Client,
+    simple_snapshot_fixture: Snapshot,
+    qtbot: QtBot
+):
+    dialog = RestoreDialog(test_client, simple_snapshot_fixture)
+    qtbot.addWidget(dialog)
+    table_view = dialog.table_view
+    model = table_view.model()
+    assert isinstance(model, RestoreDialogModel)
+    assert len(model.entries) == len(simple_snapshot_fixture.children)
+
+    assert isinstance(model, RestoreDialogModel)
+    dialog.batch_size_spinbox.setValue(2)
+    dialog.restore_batch_button.clicked.emit()
+
+    assert model.rowCount() == len(simple_snapshot_fixture.children) - 2
+    assert len(model.entries) == len(simple_snapshot_fixture.children) - 2
+    assert model.entries[0] == simple_snapshot_fixture.children[2]
 
 
 @pytest.mark.parametrize(

--- a/superscore/ui/restore_dialog.ui
+++ b/superscore/ui/restore_dialog.ui
@@ -13,8 +13,8 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0" colspan="2">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
     <widget class="QLabel" name="topLabel">
      <property name="text">
       <string>PVs to Restore</string>
@@ -24,18 +24,42 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QTableWidget" name="tableWidget"/>
+   <item>
+    <widget class="QWidget" name="table_view_placeholder" native="true"/>
    </item>
-   <item row="2" column="1">
-    <widget class="QPushButton" name="restoreButton">
+   <item>
+    <widget class="QPushButton" name="restore_all_button">
      <property name="text">
-      <string>Restore</string>
+      <string>Restore All</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QPushButton" name="cancelButton">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="topMargin">
+      <number>10</number>
+     </property>
+     <item>
+      <widget class="QPushButton" name="restore_batch_button">
+       <property name="text">
+        <string>Restore Batch of </string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="batch_size_spinbox"/>
+     </item>
+     <item>
+      <widget class="QLabel" name="pvs_label">
+       <property name="text">
+        <string>PVs</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QPushButton" name="cancel_button">
      <property name="text">
       <string>Cancel</string>
      </property>

--- a/superscore/widgets/page/restore.py
+++ b/superscore/widgets/page/restore.py
@@ -69,7 +69,23 @@ class RestoreDialogModel(QtCore.QAbstractTableModel):
     def columnCount(self, parent: Optional[QtCore.QModelIndex] = None):
         return 3
 
-    def data(self, index: QtCore.QModelIndex, role: int) -> Any:
+    def headerData(
+        self,
+        section: int,
+        orientation: QtCore.Qt.Orientation,
+        role: int = QtCore.Qt.DisplayRole
+    ) -> Any:
+        """
+        Returns the header data for the model.
+        Currently only displays horizontal header data
+        """
+        if role != QtCore.Qt.DisplayRole:
+            return
+
+        if orientation == QtCore.Qt.Horizontal:
+            return self.headers[section]
+
+    def data(self, index: QtCore.QModelIndex, role: int = QtCore.Qt.DisplayRole) -> Any:
         entry = self.entries[index.row()]
 
         if role != QtCore.Qt.DisplayRole:

--- a/superscore/widgets/page/restore.py
+++ b/superscore/widgets/page/restore.py
@@ -2,6 +2,7 @@
 
 import logging
 from functools import partial
+from typing import Any, Optional
 
 from qtpy import QtCore, QtWidgets
 from qtpy.QtGui import QCloseEvent
@@ -9,8 +10,9 @@ from qtpy.QtGui import QCloseEvent
 from superscore.client import Client
 from superscore.model import Setpoint, Snapshot
 from superscore.widgets.core import Display
-from superscore.widgets.views import (LivePVHeader, LivePVTableModel,
-                                      LivePVTableView)
+from superscore.widgets.manip_helpers import insert_widget
+from superscore.widgets.views import (ButtonDelegate, LivePVHeader,
+                                      LivePVTableModel, LivePVTableView)
 
 logger = logging.getLogger(__name__)
 
@@ -54,15 +56,76 @@ class SnapshotTableView(LivePVTableView):
         self.set_live(not self._is_live)
 
 
+class RestoreDialogModel(QtCore.QAbstractTableModel):
+    headers = ["PV Name", "Value to Restore", "Remove"]
+
+    def __init__(self, *args, entries: list[Setpoint], **kwargs):
+        super().__init__(*args, **kwargs)
+        self.entries = entries
+
+    def rowCount(self, parent: Optional[QtCore.QModelIndex] = None):
+        return len(self.entries)
+
+    def columnCount(self, parent: Optional[QtCore.QModelIndex] = None):
+        return 3
+
+    def data(self, index: QtCore.QModelIndex, role: int) -> Any:
+        entry = self.entries[index.row()]
+
+        if role != QtCore.Qt.DisplayRole:
+            return
+
+        match index.column():
+            case 0:
+                return entry.pv_name
+            case 1:
+                return entry.data
+            case 2:
+                return "Click to Remove"
+
+    def flags(self, index: QtCore.QModelIndex) -> QtCore.Qt.ItemFlags:
+        """
+        Returns the item flags for the given ``index``.  Set delegates editable
+        """
+        if index.column() != 2:
+            return QtCore.Qt.ItemIsEnabled
+
+        return QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsEditable
+
+    def removeRow(self, row: int, parent: QtCore.QModelIndex = ...) -> bool:
+        self.beginRemoveRows(QtCore.QModelIndex(), row, row)
+        self.entries.pop(row)
+        self.endRemoveRows()
+
+
+class RestoreDialogView(QtWidgets.QTableView):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setup_ui()
+
+    def setup_ui(self):
+        self.remove_delegate = ButtonDelegate(button_text='Remove')
+        self.setItemDelegateForColumn(2, self.remove_delegate)
+        self.remove_delegate.clicked.connect(self.remove_row)
+        self.horizontalHeader().setStretchLastSection(True)
+
+    def remove_row(self, index: QtCore.QModelIndex) -> None:
+        self.model().removeRow(index.row())
+
+
 class RestoreDialog(Display, QtWidgets.QWidget):
     """A dialog for selecting PVs to write to the EPICS system"""
 
     filename = "restore_dialog.ui"
 
-    cancelButton: QtWidgets.QPushButton
-    restoreButton: QtWidgets.QPushButton
+    cancel_button: QtWidgets.QPushButton
+    restore_all_button: QtWidgets.QPushButton
+    restore_batch_button: QtWidgets.QPushButton
 
-    tableWidget: QtWidgets.QTableWidget
+    batch_size_spinbox: QtWidgets.QSpinBox
+
+    table_view_placeholder: QtWidgets.QWidget
+    table_view: QtWidgets.QTableView
 
     def __init__(self, client: Client, snapshot: Snapshot = None):
         super().__init__()
@@ -70,34 +133,34 @@ class RestoreDialog(Display, QtWidgets.QWidget):
         if snapshot is None:
             self.entries = []
         else:
-            self.entries = [entry for entry in client._gather_leaves(snapshot) if isinstance(entry, Setpoint)]
+            self.entries = [entry for entry in client._gather_leaves(snapshot)
+                            if isinstance(entry, Setpoint)]
+        self._set_batch_limits()
 
-        self.tableWidget.setRowCount(len(self.entries))
-        self.tableWidget.setColumnCount(3)
-        for row, entry in enumerate(self.entries):
-            pv_item = QtWidgets.QTableWidgetItem(entry.pv_name)
-            self.tableWidget.setItem(row, 0, pv_item)
+        self.table_view = RestoreDialogView()
+        self.table_view.setModel(RestoreDialogModel(entries=self.entries))
 
-            value_item = QtWidgets.QTableWidgetItem(str(entry.data))
-            value_item.setTextAlignment(QtCore.Qt.AlignCenter)
-            self.tableWidget.setItem(row, 1, value_item)
+        insert_widget(self.table_view, self.table_view_placeholder)
 
-            remove_item = QtWidgets.QPushButton("Remove")
-            remove_item.clicked.connect(self.delete_row)
-            self.tableWidget.setCellWidget(row, 2, remove_item)
+        self.cancel_button.clicked.connect(self.deleteLater)
+        self.restore_all_button.clicked.connect(self.restore_all)
+        self.restore_batch_button.clicked.connect(self.restore_batch)
 
-        self.restoreButton.clicked.connect(self.restore)
-        self.cancelButton.clicked.connect(self.deleteLater)
-
-    def restore(self):
+    def restore_all(self):
         ephemeral_snapshot = Snapshot(children=self.entries)
         self.client.apply(ephemeral_snapshot)
         self.close()
 
-    def delete_row(self) -> None:
-        row = self.tableWidget.currentRow()
-        self.entries.pop(row)
-        self.tableWidget.removeRow(row)
+    def _set_batch_limits(self):
+        self.batch_size_spinbox.setMinimum(1)
+        self.batch_size_spinbox.setMaximum(len(self.entries))
+
+    def restore_batch(self):
+        batch_size = self.batch_size_spinbox.value()
+        ephemeral_snapshot = Snapshot(children=self.entries[:batch_size])
+        self.client.apply(ephemeral_snapshot)
+        for _ in range(batch_size):
+            self.table_view.model().removeRow(0)
 
 
 class LiveButton(QtWidgets.QPushButton):
@@ -167,7 +230,7 @@ class RestorePage(Display, QtWidgets.QWidget):
 
     def launch_dialog(self):
         self.dialog = RestoreDialog(self.client, self.snapshot)
-        self.dialog.restoreButton.clicked.connect(partial(self.tableView.set_live, True))
+        self.dialog.restore_all_button.clicked.connect(partial(self.tableView.set_live, True))
         self.dialog.show()
 
     def closeEvent(self, a0: QCloseEvent) -> None:

--- a/superscore/widgets/page/restore.py
+++ b/superscore/widgets/page/restore.py
@@ -108,10 +108,18 @@ class RestoreDialogModel(QtCore.QAbstractTableModel):
 
         return QtCore.Qt.ItemIsEnabled | QtCore.Qt.ItemIsEditable
 
-    def removeRow(self, row: int, parent: QtCore.QModelIndex = ...) -> bool:
-        self.beginRemoveRows(QtCore.QModelIndex(), row, row)
-        self.entries.pop(row)
-        self.endRemoveRows()
+    def removeRow(
+        self,
+        row: int,
+        parent: QtCore.QModelIndex = QtCore.QModelIndex()
+    ) -> bool:
+        try:
+            self.beginRemoveRows(QtCore.QModelIndex(), row, row)
+            self.entries.pop(row)
+            self.endRemoveRows()
+            return True
+        except Exception:
+            return False
 
 
 class RestoreDialogView(QtWidgets.QTableView):
@@ -163,15 +171,22 @@ class RestoreDialog(Display, QtWidgets.QWidget):
         self.restore_batch_button.clicked.connect(self.restore_batch)
 
     def restore_all(self):
+        """
+        Restore all entries from the snapshot.
+        """
         ephemeral_snapshot = Snapshot(children=self.entries)
         self.client.apply(ephemeral_snapshot)
         self.close()
 
     def _set_batch_limits(self):
+        """
+        Set the batch size spinbox limits based on the loaded entries
+        """
         self.batch_size_spinbox.setMinimum(1)
         self.batch_size_spinbox.setMaximum(len(self.entries))
 
     def restore_batch(self):
+        """Restore the a batch of PVs of size specified by the spinbox"""
         batch_size = self.batch_size_spinbox.value()
         ephemeral_snapshot = Snapshot(children=self.entries[:batch_size])
         self.client.apply(ephemeral_snapshot)

--- a/superscore/widgets/views.py
+++ b/superscore/widgets/views.py
@@ -444,7 +444,7 @@ class RootTree(QtCore.QAbstractItemModel):
         self,
         section: int,
         orientation: QtCore.Qt.Orientation,
-        role: int
+        role: int = QtCore.Qt.DisplayRole
     ) -> Any:
         """
         Returns the header data for the model.


### PR DESCRIPTION
## Description
The last feature for real

- Allows user to restore a snapshot in chunks, rather than all at once through the `RestoreDialog`
  - Refactors the table to use a proper model with button delegates for synchronizing the data model and list of entries
 
TODO:
- [ ] Consider adding this ability to the client, but in a restore batch - wait loop

## Motivation and Context
Apparently we're might restore enough PVs to crash an IOC, and we'd like to not do that

## How Has This Been Tested?
Added some tests, did some mild interactive testing

## Where Has This Been Documented?
This PR

<img width="556" height="480" alt="image" src="https://github.com/user-attachments/assets/054ea3bf-84f2-4fc5-a828-cedb0e387319" />


## Pre-merge checklist

- [x] Code works interactively
- [x] Code follows the [style guide](https://pcdshub.github.io/style.html)
- [x] Code contains descriptive docstrings, including context and API
- [x] New/changed functions and methods are covered in the test suite where possible
- [x] Test suite passes locally
- [x] Test suite passes on GitHub Actions
- [x] Ran ``docs/pre-release-notes.sh`` and created a pre-release documentation page
- [x] Pre-release docs include context, functional descriptions, and contributors as appropriate
